### PR TITLE
Add EasyReasy.Auth.Google library for Google Sign-In

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,7 @@ jobs:
           core)          PROJECT="EasyReasy";                     TEST_PROJECT="EasyReasy.Tests" ;;
           auth)          PROJECT="EasyReasy.Auth";                TEST_PROJECT="EasyReasy.Auth.Tests" ;;
           auth-client)   PROJECT="EasyReasy.Auth.Client";         TEST_PROJECT="EasyReasy.Auth.Client.Tests" ;;
+          auth-google)   PROJECT="EasyReasy.Auth.Google";         TEST_PROJECT="EasyReasy.Auth.Google.Tests" ;;
           byteshelf)     PROJECT="EasyReasy.ByteShelfProvider";   TEST_PROJECT="EasyReasy.ByteShelfProvider.Tests" ;;
           env)           PROJECT="EasyReasy.EnvironmentVariables"; TEST_PROJECT="EasyReasy.EnvironmentVariables.Tests" ;;
           vectorstorage) PROJECT="EasyReasy.VectorStorage";       TEST_PROJECT="EasyReasy.VectorStorage.Tests" ;;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-EasyReasy is a collection of independent .NET 8 NuGet packages sharing a common philosophy: type-safe, self-documenting APIs with startup-time validation. Each package is a class library published to NuGet. There is no runnable application here — only libraries and their tests.
+EasyReasy is a collection of independent .NET 10 NuGet packages sharing a common philosophy: type-safe, self-documenting APIs with startup-time validation. Each package is a class library published to NuGet. There is no runnable application here — only libraries and their tests.
 
 ## Build & Test Commands
 
@@ -17,7 +17,7 @@ dotnet test --filter "FullyQualifiedName~ClassName.MethodName" EasyReasy.Auth.Te
 
 ## Solution Structure
 
-Six independent library projects, each with a corresponding test project:
+Seven library projects, each with a corresponding test project:
 
 | Library | Purpose | Dependencies |
 |---------|---------|-------------|
@@ -26,9 +26,10 @@ Six independent library projects, each with a corresponding test project:
 | `EasyReasy.EnvironmentVariables` | Typed environment variable validation & retrieval | — |
 | `EasyReasy.Auth` | JWT auth, claims middleware, password hashing (ASP.NET Core) | — |
 | `EasyReasy.Auth.Client` | Lightweight HTTP client for Auth servers | — |
+| `EasyReasy.Auth.Google` | Google Sign-In integration for EasyReasy.Auth | `EasyReasy.Auth` |
 | `EasyReasy.VectorStorage` | In-memory cosine similarity vector search | — |
 
-Only `EasyReasy.ByteShelfProvider` depends on another library project (`EasyReasy`). All other libraries are fully independent of each other.
+`EasyReasy.ByteShelfProvider` depends on `EasyReasy` and `EasyReasy.Auth.Google` depends on `EasyReasy.Auth`. All other libraries are fully independent of each other.
 
 ## Architecture
 

--- a/EasyReasy.Auth.Google.Tests/EasyReasy.Auth.Google.Tests.csproj
+++ b/EasyReasy.Auth.Google.Tests/EasyReasy.Auth.Google.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EasyReasy.Auth.Google\EasyReasy.Auth.Google.csproj" />
+    <ProjectReference Include="..\EasyReasy.Auth\EasyReasy.Auth.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/EasyReasy.Auth.Google.Tests/FakeGoogleAuthHandler.cs
+++ b/EasyReasy.Auth.Google.Tests/FakeGoogleAuthHandler.cs
@@ -21,6 +21,13 @@ namespace EasyReasy.Auth.Google.Tests
         public GoogleUserInfo? LastReceivedUserInfo { get; private set; }
 
         /// <summary>
+        /// The last <see cref="IRefreshTokenService"/> received by <see cref="HandleGoogleUserAsync"/>,
+        /// or null if none was registered in the DI container. Lets a test verify that the endpoint
+        /// resolves a registered refresh-token service and passes it through to the handler.
+        /// </summary>
+        public IRefreshTokenService? LastReceivedRefreshTokenService { get; private set; }
+
+        /// <summary>
         /// Whether <see cref="HandleGoogleUserAsync"/> was called.
         /// </summary>
         public bool WasCalled { get; private set; }
@@ -34,6 +41,7 @@ namespace EasyReasy.Auth.Google.Tests
         {
             WasCalled = true;
             LastReceivedUserInfo = userInfo;
+            LastReceivedRefreshTokenService = refreshTokenService;
             return Task.FromResult(ResponseToReturn);
         }
     }

--- a/EasyReasy.Auth.Google.Tests/FakeGoogleAuthHandler.cs
+++ b/EasyReasy.Auth.Google.Tests/FakeGoogleAuthHandler.cs
@@ -1,0 +1,40 @@
+using EasyReasy.Auth.Google;
+using Microsoft.AspNetCore.Http;
+
+namespace EasyReasy.Auth.Google.Tests
+{
+    /// <summary>
+    /// Fake implementation of <see cref="IGoogleAuthHandler"/> for testing.
+    /// Returns a pre-configured <see cref="AuthResponse"/> and records the received <see cref="GoogleUserInfo"/>.
+    /// </summary>
+    internal class FakeGoogleAuthHandler : IGoogleAuthHandler
+    {
+        /// <summary>
+        /// The <see cref="AuthResponse"/> to return when <see cref="HandleGoogleUserAsync"/> is called.
+        /// Set to null to simulate a rejected user.
+        /// </summary>
+        public AuthResponse? ResponseToReturn { get; set; }
+
+        /// <summary>
+        /// The last <see cref="GoogleUserInfo"/> received by <see cref="HandleGoogleUserAsync"/>.
+        /// </summary>
+        public GoogleUserInfo? LastReceivedUserInfo { get; private set; }
+
+        /// <summary>
+        /// Whether <see cref="HandleGoogleUserAsync"/> was called.
+        /// </summary>
+        public bool WasCalled { get; private set; }
+
+        /// <inheritdoc />
+        public Task<AuthResponse?> HandleGoogleUserAsync(
+            GoogleUserInfo userInfo,
+            IJwtTokenService jwtTokenService,
+            IRefreshTokenService? refreshTokenService,
+            HttpContext? httpContext)
+        {
+            WasCalled = true;
+            LastReceivedUserInfo = userInfo;
+            return Task.FromResult(ResponseToReturn);
+        }
+    }
+}

--- a/EasyReasy.Auth.Google.Tests/FakeGoogleIdTokenValidator.cs
+++ b/EasyReasy.Auth.Google.Tests/FakeGoogleIdTokenValidator.cs
@@ -1,0 +1,46 @@
+using EasyReasy.Auth.Google;
+
+namespace EasyReasy.Auth.Google.Tests
+{
+    /// <summary>
+    /// Fake implementation of <see cref="IGoogleIdTokenValidator"/> for testing.
+    /// Returns a pre-configured <see cref="GoogleUserInfo"/> or throws on validation.
+    /// </summary>
+    internal class FakeGoogleIdTokenValidator : IGoogleIdTokenValidator
+    {
+        /// <summary>
+        /// The <see cref="GoogleUserInfo"/> to return when validation succeeds.
+        /// Set to null and set <see cref="ExceptionToThrow"/> to simulate validation failure.
+        /// </summary>
+        public GoogleUserInfo? UserInfoToReturn { get; set; }
+
+        /// <summary>
+        /// The exception to throw when <see cref="ValidateAsync"/> is called.
+        /// When set, the validator will throw this exception instead of returning a result.
+        /// </summary>
+        public GoogleTokenValidationException? ExceptionToThrow { get; set; }
+
+        /// <summary>
+        /// The last ID token that was passed to <see cref="ValidateAsync"/>.
+        /// </summary>
+        public string? LastValidatedToken { get; private set; }
+
+        /// <inheritdoc />
+        public Task<GoogleUserInfo> ValidateAsync(string idToken)
+        {
+            LastValidatedToken = idToken;
+
+            if (ExceptionToThrow != null)
+            {
+                throw ExceptionToThrow;
+            }
+
+            if (UserInfoToReturn == null)
+            {
+                throw new InvalidOperationException("FakeGoogleIdTokenValidator: UserInfoToReturn is not set.");
+            }
+
+            return Task.FromResult(UserInfoToReturn);
+        }
+    }
+}

--- a/EasyReasy.Auth.Google.Tests/GlobalUsings.cs
+++ b/EasyReasy.Auth.Google.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/EasyReasy.Auth.Google.Tests/GoogleAuthEndpointTests.cs
+++ b/EasyReasy.Auth.Google.Tests/GoogleAuthEndpointTests.cs
@@ -1,0 +1,198 @@
+using EasyReasy.Auth;
+using EasyReasy.Auth.Google;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace EasyReasy.Auth.Google.Tests
+{
+    /// <summary>
+    /// Integration tests that spin up an in-process <see cref="TestServer"/> hosting the real
+    /// <see cref="GoogleAuthApplicationBuilderExtensions.AddGoogleAuthEndpoint"/> and verify that a registered
+    /// <see cref="IAuthAuditLogger"/> receives exactly one <see cref="IAuthAuditLogger.OnExternalAuthAsync"/>
+    /// invocation per endpoint hit (on both the success and failure paths), that the endpoint sets the
+    /// <c>Cache-Control: no-store</c> header, that it works when no audit logger is registered, and that it
+    /// fails fast when its required services are missing.
+    /// </summary>
+    [TestClass]
+    public class GoogleAuthEndpointTests
+    {
+        private const string Secret = "super_secret_key_12345_12345_12345";
+
+        [TestMethod]
+        public async Task GoogleEndpoint_ValidToken_ReturnsOkAndInvokesAuditHook()
+        {
+            RecordingExternalAuthLogger auditLogger = new RecordingExternalAuthLogger();
+            FakeGoogleIdTokenValidator validator = new FakeGoogleIdTokenValidator
+            {
+                UserInfoToReturn = new GoogleUserInfo { Subject = "sub-123", Email = "user@example.com", EmailVerified = true },
+            };
+            FakeGoogleAuthHandler handler = new FakeGoogleAuthHandler
+            {
+                ResponseToReturn = new AuthResponse("jwt-token", "2099-01-01T00:00:00Z"),
+            };
+            await using HostedApp host = await HostedApp.StartAsync(validator, handler, auditLogger);
+
+            HttpResponseMessage response = await host.Client.PostAsJsonAsync(
+                "/api/auth/google", new { idToken = "valid-token" });
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual("no-store", response.Headers.CacheControl?.ToString());
+            Assert.AreEqual(1, auditLogger.Calls.Count);
+            Assert.IsTrue(auditLogger.Calls[0].Result.Success);
+            Assert.AreEqual("google", auditLogger.Calls[0].Result.Provider);
+            Assert.AreEqual("sub-123", auditLogger.Calls[0].Result.AttemptedSubject);
+        }
+
+        [TestMethod]
+        public async Task GoogleEndpoint_InvalidToken_ReturnsUnauthorizedAndInvokesAuditHook()
+        {
+            RecordingExternalAuthLogger auditLogger = new RecordingExternalAuthLogger();
+            FakeGoogleIdTokenValidator validator = new FakeGoogleIdTokenValidator
+            {
+                ExceptionToThrow = new GoogleTokenValidationException("Invalid token"),
+            };
+            await using HostedApp host = await HostedApp.StartAsync(validator, new FakeGoogleAuthHandler(), auditLogger);
+
+            HttpResponseMessage response = await host.Client.PostAsJsonAsync(
+                "/api/auth/google", new { idToken = "bad-token" });
+
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.AreEqual(1, auditLogger.Calls.Count);
+            Assert.IsFalse(auditLogger.Calls[0].Result.Success);
+            Assert.AreEqual(ExternalAuthFailureReason.InvalidToken, auditLogger.Calls[0].Result.FailureReason);
+            Assert.IsNull(auditLogger.Calls[0].Result.AttemptedSubject);
+        }
+
+        [TestMethod]
+        public async Task GoogleEndpoint_HandlerRejection_ReturnsUnauthorizedWithRejectedReason()
+        {
+            RecordingExternalAuthLogger auditLogger = new RecordingExternalAuthLogger();
+            FakeGoogleIdTokenValidator validator = new FakeGoogleIdTokenValidator
+            {
+                UserInfoToReturn = new GoogleUserInfo { Subject = "sub-456", Email = "rejected@example.com", EmailVerified = true },
+            };
+            FakeGoogleAuthHandler handler = new FakeGoogleAuthHandler { ResponseToReturn = null };
+            await using HostedApp host = await HostedApp.StartAsync(validator, handler, auditLogger);
+
+            HttpResponseMessage response = await host.Client.PostAsJsonAsync(
+                "/api/auth/google", new { idToken = "valid-token" });
+
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.AreEqual(1, auditLogger.Calls.Count);
+            Assert.IsFalse(auditLogger.Calls[0].Result.Success);
+            Assert.AreEqual(ExternalAuthFailureReason.Rejected, auditLogger.Calls[0].Result.FailureReason);
+            Assert.AreEqual("sub-456", auditLogger.Calls[0].Result.AttemptedSubject);
+        }
+
+        [TestMethod]
+        public async Task GoogleEndpoint_NoAuditLogger_ReturnsOk()
+        {
+            FakeGoogleIdTokenValidator validator = new FakeGoogleIdTokenValidator
+            {
+                UserInfoToReturn = new GoogleUserInfo { Subject = "sub-789", Email = "user@example.com", EmailVerified = true },
+            };
+            FakeGoogleAuthHandler handler = new FakeGoogleAuthHandler
+            {
+                ResponseToReturn = new AuthResponse("jwt-token", "2099-01-01T00:00:00Z"),
+            };
+            await using HostedApp host = await HostedApp.StartAsync(validator, handler, auditLogger: null);
+
+            HttpResponseMessage response = await host.Client.PostAsJsonAsync(
+                "/api/auth/google", new { idToken = "valid-token" });
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task GoogleEndpoint_WithoutRegisteredHandler_ThrowsAtStartup()
+        {
+            WebApplicationBuilder builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.Services.AddEasyReasyAuth(Secret);
+            builder.Services.AddEasyReasyGoogleAuth("client-id.apps.googleusercontent.com");
+            // Deliberately not registering IGoogleAuthHandler.
+
+            await using WebApplication app = builder.Build();
+
+            Assert.ThrowsException<InvalidOperationException>(() => app.AddGoogleAuthEndpoint());
+        }
+
+        /// <summary>
+        /// Builds a real <see cref="WebApplication"/> with <see cref="GoogleAuthApplicationBuilderExtensions.AddGoogleAuthEndpoint"/>
+        /// wired to test fakes, and exposes a <see cref="TestServer"/>-backed <see cref="HttpClient"/>.
+        /// </summary>
+        private sealed class HostedApp : IAsyncDisposable
+        {
+            public WebApplication App { get; }
+            public HttpClient Client { get; }
+
+            private HostedApp(WebApplication app, HttpClient client)
+            {
+                App = app;
+                Client = client;
+            }
+
+            public static async Task<HostedApp> StartAsync(
+                IGoogleIdTokenValidator validator,
+                IGoogleAuthHandler handler,
+                RecordingExternalAuthLogger? auditLogger)
+            {
+                WebApplicationBuilder builder = WebApplication.CreateBuilder();
+                builder.WebHost.UseTestServer();
+                builder.Logging.ClearProviders();
+
+                builder.Services.AddEasyReasyAuth(Secret);
+                builder.Services.AddSingleton<IGoogleIdTokenValidator>(validator);
+                builder.Services.AddSingleton<IGoogleAuthHandler>(handler);
+                builder.Services.AddScoped<GoogleAuthService>();
+
+                if (auditLogger != null)
+                {
+                    builder.Services.AddSingleton<IAuthAuditLogger>(auditLogger);
+                }
+
+                WebApplication app = builder.Build();
+                app.AddGoogleAuthEndpoint();
+
+                await app.StartAsync();
+                TestServer server = (TestServer)app.Services.GetRequiredService<IServer>();
+                HttpClient client = server.CreateClient();
+                return new HostedApp(app, client);
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                try
+                {
+                    Client.Dispose();
+                }
+                finally
+                {
+                    await App.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// In-memory <see cref="IAuthAuditLogger"/> that records every <see cref="OnExternalAuthAsync"/> invocation.
+        /// All other hooks use the interface's default no-op implementations.
+        /// </summary>
+        private sealed class RecordingExternalAuthLogger : IAuthAuditLogger
+        {
+            public List<(HttpContext HttpContext, ExternalAuthResult Result)> Calls { get; } = new List<(HttpContext, ExternalAuthResult)>();
+
+            public Task OnExternalAuthAsync(HttpContext httpContext, ExternalAuthResult result)
+            {
+                Calls.Add((httpContext, result));
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/EasyReasy.Auth.Google.Tests/GoogleAuthEndpointTests.cs
+++ b/EasyReasy.Auth.Google.Tests/GoogleAuthEndpointTests.cs
@@ -64,6 +64,7 @@ namespace EasyReasy.Auth.Google.Tests
                 "/api/auth/google", new { idToken = "bad-token" });
 
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.AreEqual("no-store", response.Headers.CacheControl?.ToString());
             Assert.AreEqual(1, auditLogger.Calls.Count);
             Assert.IsFalse(auditLogger.Calls[0].Result.Success);
             Assert.AreEqual(ExternalAuthFailureReason.InvalidToken, auditLogger.Calls[0].Result.FailureReason);
@@ -108,6 +109,27 @@ namespace EasyReasy.Auth.Google.Tests
                 "/api/auth/google", new { idToken = "valid-token" });
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task GoogleEndpoint_RefreshTokenServiceRegistered_PassesItThroughToHandler()
+        {
+            FakeGoogleIdTokenValidator validator = new FakeGoogleIdTokenValidator
+            {
+                UserInfoToReturn = new GoogleUserInfo { Subject = "sub-refresh", Email = "user@example.com", EmailVerified = true },
+            };
+            FakeGoogleAuthHandler handler = new FakeGoogleAuthHandler
+            {
+                ResponseToReturn = new AuthResponse("jwt-token", "2099-01-01T00:00:00Z"),
+            };
+            FakeRefreshTokenService refreshTokenService = new FakeRefreshTokenService();
+            await using HostedApp host = await HostedApp.StartAsync(validator, handler, auditLogger: null, refreshTokenService);
+
+            HttpResponseMessage response = await host.Client.PostAsJsonAsync(
+                "/api/auth/google", new { idToken = "valid-token" });
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreSame(refreshTokenService, handler.LastReceivedRefreshTokenService);
         }
 
         [TestMethod]
@@ -188,7 +210,8 @@ namespace EasyReasy.Auth.Google.Tests
             public static async Task<HostedApp> StartAsync(
                 IGoogleIdTokenValidator validator,
                 IGoogleAuthHandler handler,
-                IAuthAuditLogger? auditLogger)
+                IAuthAuditLogger? auditLogger,
+                IRefreshTokenService? refreshTokenService = null)
             {
                 WebApplicationBuilder builder = WebApplication.CreateBuilder();
                 builder.WebHost.UseTestServer();
@@ -202,6 +225,11 @@ namespace EasyReasy.Auth.Google.Tests
                 if (auditLogger != null)
                 {
                     builder.Services.AddSingleton<IAuthAuditLogger>(auditLogger);
+                }
+
+                if (refreshTokenService != null)
+                {
+                    builder.Services.AddSingleton<IRefreshTokenService>(refreshTokenService);
                 }
 
                 WebApplication app = builder.Build();
@@ -251,6 +279,32 @@ namespace EasyReasy.Auth.Google.Tests
             {
                 throw new InvalidOperationException("audit logger failure");
             }
+        }
+
+        /// <summary>
+        /// Inert <see cref="IRefreshTokenService"/> used only to assert that the endpoint resolves a
+        /// registered refresh-token service and passes the same instance through to the handler. None of
+        /// its members are exercised by that path, so they throw rather than return fabricated results.
+        /// </summary>
+        private sealed class FakeRefreshTokenService : IRefreshTokenService
+        {
+            public Task<string> CreateRefreshTokenAsync(string subject, string authType, string? serializedClaims, string? serializedRoles, CancellationToken cancellationToken = default)
+                => throw new NotImplementedException();
+
+            public Task<RefreshTokenCreationResult> CreateRefreshTokenWithFamilyAsync(string subject, string authType, string? serializedClaims, string? serializedRoles, CancellationToken cancellationToken = default)
+                => throw new NotImplementedException();
+
+            public Task<RefreshResult> RefreshAsync(string refreshToken, IJwtTokenService jwtTokenService, HttpContext? httpContext = null, CancellationToken cancellationToken = default)
+                => throw new NotImplementedException();
+
+            public Task<LogoutResult> LogoutAsync(string? refreshToken, HttpContext? httpContext = null, CancellationToken cancellationToken = default)
+                => throw new NotImplementedException();
+
+            public Task<SessionRevocationResult> InvalidateAllSessionsAsync(string subject, CancellationToken cancellationToken = default)
+                => throw new NotImplementedException();
+
+            public Task RetireFamilyAsync(string? familyId, string? subject = null, HttpContext? httpContext = null, CancellationToken cancellationToken = default)
+                => throw new NotImplementedException();
         }
     }
 }

--- a/EasyReasy.Auth.Google.Tests/GoogleAuthEndpointTests.cs
+++ b/EasyReasy.Auth.Google.Tests/GoogleAuthEndpointTests.cs
@@ -124,6 +124,52 @@ namespace EasyReasy.Auth.Google.Tests
             Assert.ThrowsException<InvalidOperationException>(() => app.AddGoogleAuthEndpoint());
         }
 
+        [TestMethod]
+        public async Task GoogleEndpoint_WithoutRegisteredValidator_ThrowsAtStartup()
+        {
+            WebApplicationBuilder builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.Services.AddEasyReasyAuth(Secret);
+            // Deliberately not calling AddEasyReasyGoogleAuth, so IGoogleIdTokenValidator is absent.
+
+            await using WebApplication app = builder.Build();
+
+            Assert.ThrowsException<InvalidOperationException>(() => app.AddGoogleAuthEndpoint());
+        }
+
+        [TestMethod]
+        public async Task GoogleEndpoint_WithoutRegisteredJwtTokenService_ThrowsAtStartup()
+        {
+            WebApplicationBuilder builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.Services.AddEasyReasyGoogleAuth("client-id.apps.googleusercontent.com");
+            builder.Services.AddScoped<IGoogleAuthHandler, FakeGoogleAuthHandler>();
+            // Deliberately not calling AddEasyReasyAuth, so IJwtTokenService is absent.
+
+            await using WebApplication app = builder.Build();
+
+            Assert.ThrowsException<InvalidOperationException>(() => app.AddGoogleAuthEndpoint());
+        }
+
+        [TestMethod]
+        public async Task GoogleEndpoint_AuditLoggerThrows_PropagatesOutOfEndpoint()
+        {
+            FakeGoogleIdTokenValidator validator = new FakeGoogleIdTokenValidator
+            {
+                UserInfoToReturn = new GoogleUserInfo { Subject = "sub-1", Email = "user@example.com", EmailVerified = true },
+            };
+            FakeGoogleAuthHandler handler = new FakeGoogleAuthHandler
+            {
+                ResponseToReturn = new AuthResponse("jwt-token", "2099-01-01T00:00:00Z"),
+            };
+            await using HostedApp host = await HostedApp.StartAsync(validator, handler, new ThrowingExternalAuthLogger());
+
+            // The endpoint does not swallow audit-logger failures. Under TestServer the unhandled exception
+            // surfaces directly on the call; in a hosted server it would become a 500.
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => host.Client.PostAsJsonAsync("/api/auth/google", new { idToken = "valid-token" }));
+        }
+
         /// <summary>
         /// Builds a real <see cref="WebApplication"/> with <see cref="GoogleAuthApplicationBuilderExtensions.AddGoogleAuthEndpoint"/>
         /// wired to test fakes, and exposes a <see cref="TestServer"/>-backed <see cref="HttpClient"/>.
@@ -142,7 +188,7 @@ namespace EasyReasy.Auth.Google.Tests
             public static async Task<HostedApp> StartAsync(
                 IGoogleIdTokenValidator validator,
                 IGoogleAuthHandler handler,
-                RecordingExternalAuthLogger? auditLogger)
+                IAuthAuditLogger? auditLogger)
             {
                 WebApplicationBuilder builder = WebApplication.CreateBuilder();
                 builder.WebHost.UseTestServer();
@@ -192,6 +238,18 @@ namespace EasyReasy.Auth.Google.Tests
             {
                 Calls.Add((httpContext, result));
                 return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>
+        /// <see cref="IAuthAuditLogger"/> whose <see cref="OnExternalAuthAsync"/> always throws, used to verify
+        /// that an audit-logger failure propagates out of the endpoint rather than being swallowed.
+        /// </summary>
+        private sealed class ThrowingExternalAuthLogger : IAuthAuditLogger
+        {
+            public Task OnExternalAuthAsync(HttpContext httpContext, ExternalAuthResult result)
+            {
+                throw new InvalidOperationException("audit logger failure");
             }
         }
     }

--- a/EasyReasy.Auth.Google.Tests/GoogleAuthRequestTests.cs
+++ b/EasyReasy.Auth.Google.Tests/GoogleAuthRequestTests.cs
@@ -1,0 +1,69 @@
+using EasyReasy.Auth.Google;
+
+namespace EasyReasy.Auth.Google.Tests
+{
+    [TestClass]
+    public class GoogleAuthRequestTests
+    {
+        [TestMethod]
+        public void Constructor_SetsIdToken()
+        {
+            GoogleAuthRequest request = new GoogleAuthRequest("test-token-123");
+
+            Assert.AreEqual("test-token-123", request.IdToken);
+        }
+
+        [TestMethod]
+        public void ToJson_SerializesCorrectly()
+        {
+            GoogleAuthRequest request = new GoogleAuthRequest("my-id-token");
+
+            string json = request.ToJson();
+
+            Assert.AreEqual("{\"idToken\":\"my-id-token\"}", json);
+        }
+
+        [TestMethod]
+        public void FromJson_DeserializesCorrectly()
+        {
+            string json = "{\"idToken\":\"my-id-token\"}";
+
+            GoogleAuthRequest request = GoogleAuthRequest.FromJson(json);
+
+            Assert.AreEqual("my-id-token", request.IdToken);
+        }
+
+        [TestMethod]
+        public void FromJson_RoundTrip_PreservesValues()
+        {
+            GoogleAuthRequest original = new GoogleAuthRequest("round-trip-token");
+
+            string json = original.ToJson();
+            GoogleAuthRequest deserialized = GoogleAuthRequest.FromJson(json);
+
+            Assert.AreEqual(original.IdToken, deserialized.IdToken);
+        }
+
+        [TestMethod]
+        public void ToString_ReturnsJson()
+        {
+            GoogleAuthRequest request = new GoogleAuthRequest("some-token");
+
+            string result = request.ToString();
+
+            Assert.AreEqual(request.ToJson(), result);
+        }
+
+        [TestMethod]
+        public void FromJson_InvalidJson_ThrowsArgumentException()
+        {
+            Assert.ThrowsException<ArgumentException>(() => GoogleAuthRequest.FromJson("not valid json"));
+        }
+
+        [TestMethod]
+        public void FromJson_NullResult_ThrowsArgumentException()
+        {
+            Assert.ThrowsException<ArgumentException>(() => GoogleAuthRequest.FromJson("null"));
+        }
+    }
+}

--- a/EasyReasy.Auth.Google.Tests/GoogleAuthRequestTests.cs
+++ b/EasyReasy.Auth.Google.Tests/GoogleAuthRequestTests.cs
@@ -45,13 +45,14 @@ namespace EasyReasy.Auth.Google.Tests
         }
 
         [TestMethod]
-        public void ToString_ReturnsJson()
+        public void ToString_RedactsIdToken()
         {
-            GoogleAuthRequest request = new GoogleAuthRequest("some-token");
+            GoogleAuthRequest request = new GoogleAuthRequest("super-secret-token");
 
             string result = request.ToString();
 
-            Assert.AreEqual(request.ToJson(), result);
+            Assert.AreEqual("{\"idToken\":\"[REDACTED]\"}", result);
+            Assert.IsFalse(result.Contains("super-secret-token"));
         }
 
         [TestMethod]

--- a/EasyReasy.Auth.Google.Tests/GoogleAuthServiceCollectionExtensionsTests.cs
+++ b/EasyReasy.Auth.Google.Tests/GoogleAuthServiceCollectionExtensionsTests.cs
@@ -1,0 +1,50 @@
+using EasyReasy.Auth.Google;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EasyReasy.Auth.Google.Tests
+{
+    /// <summary>
+    /// DI-level tests proving what <see cref="GoogleAuthServiceCollectionExtensions.AddEasyReasyGoogleAuth"/>
+    /// registers — and, deliberately, what it leaves to the consumer (the <see cref="IGoogleAuthHandler"/>).
+    /// </summary>
+    [TestClass]
+    public class GoogleAuthServiceCollectionExtensionsTests
+    {
+        private const string ClientId = "client-id.apps.googleusercontent.com";
+
+        [TestMethod]
+        public void AddEasyReasyGoogleAuth_RegistersTokenValidator()
+        {
+            ServiceCollection services = new ServiceCollection();
+            services.AddEasyReasyGoogleAuth(ClientId);
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+
+            Assert.IsNotNull(provider.GetService<IGoogleIdTokenValidator>());
+        }
+
+        [TestMethod]
+        public void AddEasyReasyGoogleAuth_RegistersGoogleAuthService_WhenHandlerProvided()
+        {
+            ServiceCollection services = new ServiceCollection();
+            services.AddEasyReasyGoogleAuth(ClientId);
+            services.AddScoped<IGoogleAuthHandler, FakeGoogleAuthHandler>();
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+            using IServiceScope scope = provider.CreateScope();
+
+            Assert.IsNotNull(scope.ServiceProvider.GetService<GoogleAuthService>());
+        }
+
+        [TestMethod]
+        public void AddEasyReasyGoogleAuth_DoesNotRegisterHandler()
+        {
+            ServiceCollection services = new ServiceCollection();
+            services.AddEasyReasyGoogleAuth(ClientId);
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+
+            Assert.IsNull(provider.GetService<IGoogleAuthHandler>());
+        }
+    }
+}

--- a/EasyReasy.Auth.Google.Tests/GoogleAuthServiceCollectionExtensionsTests.cs
+++ b/EasyReasy.Auth.Google.Tests/GoogleAuthServiceCollectionExtensionsTests.cs
@@ -46,5 +46,28 @@ namespace EasyReasy.Auth.Google.Tests
 
             Assert.IsNull(provider.GetService<IGoogleAuthHandler>());
         }
+
+        [TestMethod]
+        public void AddEasyReasyGoogleAuth_PopulatesOptionsFromArguments()
+        {
+            ServiceCollection services = new ServiceCollection();
+            services.AddEasyReasyGoogleAuth(ClientId, new[] { "example.com" }, requireVerifiedEmail: false);
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+            GoogleAuthOptions options = provider.GetRequiredService<GoogleAuthOptions>();
+
+            Assert.AreEqual(ClientId, options.ClientId);
+            Assert.IsNotNull(options.AllowedHostedDomains);
+            Assert.IsTrue(options.AllowedHostedDomains!.Contains("example.com"));
+            Assert.IsFalse(options.RequireVerifiedEmail);
+        }
+
+        [TestMethod]
+        public void AddEasyReasyGoogleAuth_BlankClientId_Throws()
+        {
+            ServiceCollection services = new ServiceCollection();
+
+            Assert.ThrowsException<ArgumentException>(() => services.AddEasyReasyGoogleAuth("   "));
+        }
     }
 }

--- a/EasyReasy.Auth.Google.Tests/GoogleAuthServiceTests.cs
+++ b/EasyReasy.Auth.Google.Tests/GoogleAuthServiceTests.cs
@@ -1,0 +1,149 @@
+using EasyReasy.Auth.Google;
+using System.Security.Claims;
+
+namespace EasyReasy.Auth.Google.Tests
+{
+    [TestClass]
+    public class GoogleAuthServiceTests
+    {
+        private FakeGoogleIdTokenValidator _fakeValidator = null!;
+        private FakeGoogleAuthHandler _fakeHandler = null!;
+        private StubJwtTokenService _stubJwtTokenService = null!;
+        private GoogleAuthService _service = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _fakeValidator = new FakeGoogleIdTokenValidator();
+            _fakeHandler = new FakeGoogleAuthHandler();
+            _stubJwtTokenService = new StubJwtTokenService();
+            _service = new GoogleAuthService(_fakeValidator, _fakeHandler);
+        }
+
+        [TestMethod]
+        public async Task AuthenticateAsync_ValidToken_ReturnsSucceededResult()
+        {
+            GoogleUserInfo userInfo = new GoogleUserInfo
+            {
+                Subject = "sub-123",
+                Email = "test@example.com",
+                EmailVerified = true,
+                Name = "Test User",
+            };
+            _fakeValidator.UserInfoToReturn = userInfo;
+
+            AuthResponse expectedResponse = new AuthResponse("jwt-token", "2099-01-01T00:00:00Z");
+            _fakeHandler.ResponseToReturn = expectedResponse;
+
+            ExternalAuthResult result = await _service.AuthenticateAsync("valid-google-token", _stubJwtTokenService, null, null);
+
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual("google", result.Provider);
+            Assert.AreEqual("sub-123", result.AttemptedSubject);
+            Assert.IsNull(result.FailureReason);
+            Assert.IsNotNull(result.AuthResponse);
+            Assert.AreEqual("jwt-token", result.AuthResponse.Token);
+            Assert.AreEqual("2099-01-01T00:00:00Z", result.AuthResponse.ExpiresAt);
+        }
+
+        [TestMethod]
+        public async Task AuthenticateAsync_InvalidToken_ReturnsInvalidTokenFailure()
+        {
+            _fakeValidator.ExceptionToThrow = new GoogleTokenValidationException("Invalid token");
+
+            ExternalAuthResult result = await _service.AuthenticateAsync("bad-token", _stubJwtTokenService, null, null);
+
+            Assert.IsFalse(result.Success);
+            Assert.AreEqual("google", result.Provider);
+            Assert.IsNull(result.AuthResponse);
+            Assert.AreEqual(ExternalAuthFailureReason.InvalidToken, result.FailureReason);
+            Assert.IsNull(result.AttemptedSubject);
+        }
+
+        [TestMethod]
+        public async Task AuthenticateAsync_InvalidToken_HandlerNotCalled()
+        {
+            _fakeValidator.ExceptionToThrow = new GoogleTokenValidationException("Invalid token");
+
+            await _service.AuthenticateAsync("bad-token", _stubJwtTokenService, null, null);
+
+            Assert.IsFalse(_fakeHandler.WasCalled);
+        }
+
+        [TestMethod]
+        public async Task AuthenticateAsync_HandlerReturnsNull_ReturnsRejectedFailure()
+        {
+            _fakeValidator.UserInfoToReturn = new GoogleUserInfo
+            {
+                Subject = "sub-456",
+                Email = "rejected@example.com",
+                EmailVerified = true,
+            };
+            _fakeHandler.ResponseToReturn = null;
+
+            ExternalAuthResult result = await _service.AuthenticateAsync("valid-token", _stubJwtTokenService, null, null);
+
+            Assert.IsFalse(result.Success);
+            Assert.AreEqual("google", result.Provider);
+            Assert.IsNull(result.AuthResponse);
+            Assert.AreEqual(ExternalAuthFailureReason.Rejected, result.FailureReason);
+            Assert.AreEqual("sub-456", result.AttemptedSubject);
+        }
+
+        [TestMethod]
+        public async Task AuthenticateAsync_UserInfoPassedToHandler()
+        {
+            GoogleUserInfo userInfo = new GoogleUserInfo
+            {
+                Subject = "sub-789",
+                Email = "details@example.com",
+                EmailVerified = true,
+                Name = "Detailed User",
+                PictureUrl = "https://example.com/pic.jpg",
+            };
+            _fakeValidator.UserInfoToReturn = userInfo;
+            _fakeHandler.ResponseToReturn = new AuthResponse("token", "2099-01-01T00:00:00Z");
+
+            await _service.AuthenticateAsync("some-token", _stubJwtTokenService, null, null);
+
+            Assert.IsNotNull(_fakeHandler.LastReceivedUserInfo);
+            Assert.AreEqual("sub-789", _fakeHandler.LastReceivedUserInfo.Subject);
+            Assert.AreEqual("details@example.com", _fakeHandler.LastReceivedUserInfo.Email);
+            Assert.AreEqual("Detailed User", _fakeHandler.LastReceivedUserInfo.Name);
+            Assert.AreEqual("https://example.com/pic.jpg", _fakeHandler.LastReceivedUserInfo.PictureUrl);
+        }
+
+        [TestMethod]
+        public async Task AuthenticateAsync_IdTokenPassedToValidator()
+        {
+            _fakeValidator.UserInfoToReturn = new GoogleUserInfo
+            {
+                Subject = "sub-abc",
+                Email = "abc@example.com",
+                EmailVerified = true,
+            };
+            _fakeHandler.ResponseToReturn = new AuthResponse("token", "2099-01-01T00:00:00Z");
+
+            await _service.AuthenticateAsync("specific-id-token", _stubJwtTokenService, null, null);
+
+            Assert.AreEqual("specific-id-token", _fakeValidator.LastValidatedToken);
+        }
+
+        /// <summary>
+        /// Minimal stub for <see cref="IJwtTokenService"/> used in tests where the service
+        /// is passed through but not directly invoked by <see cref="GoogleAuthService"/>.
+        /// </summary>
+        private class StubJwtTokenService : IJwtTokenService
+        {
+            public string CreateToken(
+                string subject,
+                string authType,
+                IEnumerable<Claim> additionalClaims,
+                IEnumerable<string> roles,
+                DateTime expiresAt)
+            {
+                return "stub-token";
+            }
+        }
+    }
+}

--- a/EasyReasy.Auth.Google.Tests/GoogleAuthServiceTests.cs
+++ b/EasyReasy.Auth.Google.Tests/GoogleAuthServiceTests.cs
@@ -129,6 +129,28 @@ namespace EasyReasy.Auth.Google.Tests
             Assert.AreEqual("specific-id-token", _fakeValidator.LastValidatedToken);
         }
 
+        [TestMethod]
+        public async Task AuthenticateAsync_EmptyIdToken_ReturnsInvalidTokenWithoutCallingValidator()
+        {
+            ExternalAuthResult result = await _service.AuthenticateAsync("", _stubJwtTokenService, null, null);
+
+            Assert.IsFalse(result.Success);
+            Assert.AreEqual(ExternalAuthFailureReason.InvalidToken, result.FailureReason);
+            Assert.IsNull(_fakeValidator.LastValidatedToken);
+            Assert.IsFalse(_fakeHandler.WasCalled);
+        }
+
+        [TestMethod]
+        public async Task AuthenticateAsync_WhitespaceIdToken_ReturnsInvalidTokenWithoutCallingValidator()
+        {
+            ExternalAuthResult result = await _service.AuthenticateAsync("   ", _stubJwtTokenService, null, null);
+
+            Assert.IsFalse(result.Success);
+            Assert.AreEqual(ExternalAuthFailureReason.InvalidToken, result.FailureReason);
+            Assert.IsNull(_fakeValidator.LastValidatedToken);
+            Assert.IsFalse(_fakeHandler.WasCalled);
+        }
+
         /// <summary>
         /// Minimal stub for <see cref="IJwtTokenService"/> used in tests where the service
         /// is passed through but not directly invoked by <see cref="GoogleAuthService"/>.

--- a/EasyReasy.Auth.Google.Tests/GoogleIdTokenValidatorTests.cs
+++ b/EasyReasy.Auth.Google.Tests/GoogleIdTokenValidatorTests.cs
@@ -13,7 +13,7 @@ namespace EasyReasy.Auth.Google.Tests
     {
         private static GoogleJsonWebSignature.Payload CreatePayload(
             string subject = "sub-1",
-            string email = "user@example.com",
+            string? email = "user@example.com",
             bool emailVerified = true,
             string? hostedDomain = null,
             string? name = "Test User",
@@ -119,6 +119,26 @@ namespace EasyReasy.Auth.Google.Tests
             GoogleUserInfo userInfo = GoogleIdTokenValidator.ValidatePolicyAndBuildUserInfo(payload, options);
 
             Assert.IsFalse(userInfo.EmailVerified);
+        }
+
+        [TestMethod]
+        public void ValidatePolicyAndBuildUserInfo_EmptyAllowedDomains_AcceptsAnyDomain()
+        {
+            GoogleAuthOptions options = new GoogleAuthOptions { ClientId = "client-id", AllowedHostedDomains = new string[0] };
+            GoogleJsonWebSignature.Payload payload = CreatePayload(hostedDomain: "anything.com");
+
+            GoogleUserInfo userInfo = GoogleIdTokenValidator.ValidatePolicyAndBuildUserInfo(payload, options);
+
+            Assert.AreEqual("user@example.com", userInfo.Email);
+        }
+
+        [TestMethod]
+        public void ValidatePolicyAndBuildUserInfo_MissingEmail_Throws()
+        {
+            GoogleAuthOptions options = new GoogleAuthOptions { ClientId = "client-id", RequireVerifiedEmail = false };
+            GoogleJsonWebSignature.Payload payload = CreatePayload(email: null, emailVerified: false);
+
+            Assert.ThrowsException<GoogleTokenValidationException>(() => GoogleIdTokenValidator.ValidatePolicyAndBuildUserInfo(payload, options));
         }
     }
 }

--- a/EasyReasy.Auth.Google.Tests/GoogleIdTokenValidatorTests.cs
+++ b/EasyReasy.Auth.Google.Tests/GoogleIdTokenValidatorTests.cs
@@ -1,0 +1,124 @@
+using EasyReasy.Auth.Google;
+using Google.Apis.Auth;
+
+namespace EasyReasy.Auth.Google.Tests
+{
+    /// <summary>
+    /// Unit tests for the post-validation policy in <see cref="GoogleIdTokenValidator.ValidatePolicyAndBuildUserInfo"/> —
+    /// hosted-domain allowlisting, email-verification enforcement, and payload mapping. The network-bound
+    /// token validation itself is not exercised here.
+    /// </summary>
+    [TestClass]
+    public class GoogleIdTokenValidatorTests
+    {
+        private static GoogleJsonWebSignature.Payload CreatePayload(
+            string subject = "sub-1",
+            string email = "user@example.com",
+            bool emailVerified = true,
+            string? hostedDomain = null,
+            string? name = "Test User",
+            string? picture = "https://example.com/p.jpg")
+        {
+            return new GoogleJsonWebSignature.Payload
+            {
+                Subject = subject,
+                Email = email,
+                EmailVerified = emailVerified,
+                HostedDomain = hostedDomain,
+                Name = name,
+                Picture = picture,
+            };
+        }
+
+        [TestMethod]
+        public void ValidatePolicyAndBuildUserInfo_MapsAllPayloadFields()
+        {
+            GoogleAuthOptions options = new GoogleAuthOptions { ClientId = "client-id" };
+            GoogleJsonWebSignature.Payload payload = CreatePayload(
+                subject: "sub-42",
+                email: "person@example.com",
+                emailVerified: true,
+                name: "Person",
+                picture: "https://example.com/x.jpg");
+
+            GoogleUserInfo userInfo = GoogleIdTokenValidator.ValidatePolicyAndBuildUserInfo(payload, options);
+
+            Assert.AreEqual("sub-42", userInfo.Subject);
+            Assert.AreEqual("person@example.com", userInfo.Email);
+            Assert.IsTrue(userInfo.EmailVerified);
+            Assert.AreEqual("Person", userInfo.Name);
+            Assert.AreEqual("https://example.com/x.jpg", userInfo.PictureUrl);
+        }
+
+        [TestMethod]
+        public void ValidatePolicyAndBuildUserInfo_NoAllowedDomains_AcceptsAnyDomain()
+        {
+            GoogleAuthOptions options = new GoogleAuthOptions { ClientId = "client-id" };
+            GoogleJsonWebSignature.Payload payload = CreatePayload(hostedDomain: "anything.com");
+
+            GoogleUserInfo userInfo = GoogleIdTokenValidator.ValidatePolicyAndBuildUserInfo(payload, options);
+
+            Assert.AreEqual("user@example.com", userInfo.Email);
+        }
+
+        [TestMethod]
+        public void ValidatePolicyAndBuildUserInfo_AllowedDomainExactMatch_Accepts()
+        {
+            GoogleAuthOptions options = new GoogleAuthOptions { ClientId = "client-id", AllowedHostedDomains = new[] { "example.com" } };
+            GoogleJsonWebSignature.Payload payload = CreatePayload(hostedDomain: "example.com");
+
+            GoogleUserInfo userInfo = GoogleIdTokenValidator.ValidatePolicyAndBuildUserInfo(payload, options);
+
+            Assert.AreEqual("user@example.com", userInfo.Email);
+        }
+
+        [TestMethod]
+        public void ValidatePolicyAndBuildUserInfo_AllowedDomainDifferentCase_Accepts()
+        {
+            GoogleAuthOptions options = new GoogleAuthOptions { ClientId = "client-id", AllowedHostedDomains = new[] { "Example.COM" } };
+            GoogleJsonWebSignature.Payload payload = CreatePayload(hostedDomain: "example.com");
+
+            GoogleUserInfo userInfo = GoogleIdTokenValidator.ValidatePolicyAndBuildUserInfo(payload, options);
+
+            Assert.AreEqual("user@example.com", userInfo.Email);
+        }
+
+        [TestMethod]
+        public void ValidatePolicyAndBuildUserInfo_DisallowedDomain_Throws()
+        {
+            GoogleAuthOptions options = new GoogleAuthOptions { ClientId = "client-id", AllowedHostedDomains = new[] { "example.com" } };
+            GoogleJsonWebSignature.Payload payload = CreatePayload(hostedDomain: "evil.com");
+
+            Assert.ThrowsException<GoogleTokenValidationException>(() => GoogleIdTokenValidator.ValidatePolicyAndBuildUserInfo(payload, options));
+        }
+
+        [TestMethod]
+        public void ValidatePolicyAndBuildUserInfo_MissingHostedDomainWhenRestricted_Throws()
+        {
+            GoogleAuthOptions options = new GoogleAuthOptions { ClientId = "client-id", AllowedHostedDomains = new[] { "example.com" } };
+            GoogleJsonWebSignature.Payload payload = CreatePayload(hostedDomain: null);
+
+            Assert.ThrowsException<GoogleTokenValidationException>(() => GoogleIdTokenValidator.ValidatePolicyAndBuildUserInfo(payload, options));
+        }
+
+        [TestMethod]
+        public void ValidatePolicyAndBuildUserInfo_UnverifiedEmailWhenRequired_Throws()
+        {
+            GoogleAuthOptions options = new GoogleAuthOptions { ClientId = "client-id" }; // RequireVerifiedEmail defaults to true
+            GoogleJsonWebSignature.Payload payload = CreatePayload(emailVerified: false);
+
+            Assert.ThrowsException<GoogleTokenValidationException>(() => GoogleIdTokenValidator.ValidatePolicyAndBuildUserInfo(payload, options));
+        }
+
+        [TestMethod]
+        public void ValidatePolicyAndBuildUserInfo_UnverifiedEmailWhenNotRequired_Accepts()
+        {
+            GoogleAuthOptions options = new GoogleAuthOptions { ClientId = "client-id", RequireVerifiedEmail = false };
+            GoogleJsonWebSignature.Payload payload = CreatePayload(emailVerified: false);
+
+            GoogleUserInfo userInfo = GoogleIdTokenValidator.ValidatePolicyAndBuildUserInfo(payload, options);
+
+            Assert.IsFalse(userInfo.EmailVerified);
+        }
+    }
+}

--- a/EasyReasy.Auth.Google.Tests/GoogleUserInfoTests.cs
+++ b/EasyReasy.Auth.Google.Tests/GoogleUserInfoTests.cs
@@ -1,0 +1,56 @@
+using EasyReasy.Auth.Google;
+
+namespace EasyReasy.Auth.Google.Tests
+{
+    [TestClass]
+    public class GoogleUserInfoTests
+    {
+        [TestMethod]
+        public void RequiredProperties_AreStored()
+        {
+            GoogleUserInfo userInfo = new GoogleUserInfo
+            {
+                Subject = "google-sub-123",
+                Email = "user@example.com",
+                EmailVerified = true,
+            };
+
+            Assert.AreEqual("google-sub-123", userInfo.Subject);
+            Assert.AreEqual("user@example.com", userInfo.Email);
+            Assert.IsTrue(userInfo.EmailVerified);
+        }
+
+        [TestMethod]
+        public void OptionalProperties_DefaultToNull()
+        {
+            GoogleUserInfo userInfo = new GoogleUserInfo
+            {
+                Subject = "google-sub-456",
+                Email = "another@example.com",
+                EmailVerified = false,
+            };
+
+            Assert.IsNull(userInfo.Name);
+            Assert.IsNull(userInfo.PictureUrl);
+        }
+
+        [TestMethod]
+        public void AllProperties_CanBeSet()
+        {
+            GoogleUserInfo userInfo = new GoogleUserInfo
+            {
+                Subject = "google-sub-789",
+                Email = "full@example.com",
+                EmailVerified = true,
+                Name = "Full User",
+                PictureUrl = "https://example.com/photo.jpg",
+            };
+
+            Assert.AreEqual("google-sub-789", userInfo.Subject);
+            Assert.AreEqual("full@example.com", userInfo.Email);
+            Assert.IsTrue(userInfo.EmailVerified);
+            Assert.AreEqual("Full User", userInfo.Name);
+            Assert.AreEqual("https://example.com/photo.jpg", userInfo.PictureUrl);
+        }
+    }
+}

--- a/EasyReasy.Auth.Google/EasyReasy.Auth.Google.csproj
+++ b/EasyReasy.Auth.Google/EasyReasy.Auth.Google.csproj
@@ -1,24 +1,25 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Title>EasyReasy.Auth</Title>
+    <Title>EasyReasy.Auth.Google</Title>
     <Authors>Adam Tovatt</Authors>
-    <Description>A lightweight .NET library for internal JWT authentication and claims handling</Description>
+    <Description>Google Sign-In integration for EasyReasy.Auth JWT authentication</Description>
     <Copyright>MIT</Copyright>
     <PackageProjectUrl>https://github.com/AdamTovatt/easy-reasy</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/AdamTovatt/easy-reasy</RepositoryUrl>
-    <PackageTags>auth;jwt;claims;easyreasy</PackageTags>
+    <PackageTags>auth;jwt;google;signin;easyreasy</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <VersionPrefix>5.3.0</VersionPrefix>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <PackageIcon>BaseIcon.png</PackageIcon>
+    <PackageReleaseNotes></PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,13 +30,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="EasyReasy.Auth.Tests" />
+    <InternalsVisibleTo Include="EasyReasy.Auth.Google.Tests" />
   </ItemGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.68.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EasyReasy.Auth\EasyReasy.Auth.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EasyReasy.Auth.Google/GoogleAuthApplicationBuilderExtensions.cs
+++ b/EasyReasy.Auth.Google/GoogleAuthApplicationBuilderExtensions.cs
@@ -1,0 +1,94 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EasyReasy.Auth.Google
+{
+    /// <summary>
+    /// Extension methods for adding Google authentication endpoints to the application.
+    /// </summary>
+    public static class GoogleAuthApplicationBuilderExtensions
+    {
+        private const string NoCacheHeaderValue = "no-store";
+
+        /// <summary>
+        /// Adds a Google authentication endpoint at <c>POST /api/auth/google</c>.
+        /// Expects a JSON body with an <c>idToken</c> field containing the Google ID token.
+        /// </summary>
+        /// <remarks>
+        /// The endpoint is anonymous (so it stays reachable when the application applies a global authorization
+        /// policy) and sets <c>Cache-Control: no-store</c> so the issued token is never cached, matching the
+        /// built-in EasyReasy.Auth endpoints. If an <see cref="IAuthAuditLogger"/> is registered, its
+        /// <see cref="IAuthAuditLogger.OnExternalAuthAsync"/> hook is invoked after the attempt (success or
+        /// failure) before the response is written; an exception thrown by the logger propagates as a 500.
+        /// </remarks>
+        /// <param name="app">The web application.</param>
+        /// <returns>The web application for chaining.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown at startup if <see cref="IGoogleIdTokenValidator"/> (registered by <c>AddEasyReasyGoogleAuth</c>),
+        /// the consumer-supplied <see cref="IGoogleAuthHandler"/>, or <see cref="IJwtTokenService"/> (registered by
+        /// <c>AddEasyReasyAuth</c>) is missing from the DI container, so a misconfiguration fails fast instead of
+        /// as a per-request 500.
+        /// </exception>
+        public static WebApplication AddGoogleAuthEndpoint(this WebApplication app)
+        {
+            EnsureRequiredServicesRegistered(app);
+
+            app.MapPost("/api/auth/google", async (GoogleAuthRequest request, IJwtTokenService jwtTokenService, GoogleAuthService googleAuthService, HttpContext httpContext) =>
+            {
+                httpContext.Response.Headers["Cache-Control"] = NoCacheHeaderValue;
+
+                IRefreshTokenService? refreshTokenService = httpContext.RequestServices.GetService<IRefreshTokenService>();
+
+                ExternalAuthResult result = await googleAuthService.AuthenticateAsync(
+                    request.IdToken,
+                    jwtTokenService,
+                    refreshTokenService,
+                    httpContext);
+
+                IAuthAuditLogger? auditLogger = httpContext.RequestServices.GetService<IAuthAuditLogger>();
+                if (auditLogger != null)
+                {
+                    await auditLogger.OnExternalAuthAsync(httpContext, result);
+                }
+
+                return result.Success && result.AuthResponse != null
+                    ? Results.Ok(result.AuthResponse)
+                    : Results.Unauthorized();
+            }).AllowAnonymous();
+
+            return app;
+        }
+
+        /// <summary>
+        /// Verifies, without instantiating them, that the services the Google endpoint depends on are
+        /// registered, so a misconfiguration surfaces as a clear startup error rather than a per-request 500.
+        /// </summary>
+        private static void EnsureRequiredServicesRegistered(WebApplication app)
+        {
+            IServiceProviderIsService serviceCheck = app.Services.GetRequiredService<IServiceProviderIsService>();
+
+            if (!serviceCheck.IsService(typeof(IGoogleIdTokenValidator)))
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(IGoogleIdTokenValidator)} is not registered in the DI container. " +
+                    $"Call builder.Services.AddEasyReasyGoogleAuth(...) before {nameof(AddGoogleAuthEndpoint)}.");
+            }
+
+            if (!serviceCheck.IsService(typeof(IGoogleAuthHandler)))
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(IGoogleAuthHandler)} is not registered in the DI container. " +
+                    $"Register your handler before {nameof(AddGoogleAuthEndpoint)}, e.g.: " +
+                    $"builder.Services.AddScoped<{nameof(IGoogleAuthHandler)}, MyGoogleAuthHandler>();");
+            }
+
+            if (!serviceCheck.IsService(typeof(IJwtTokenService)))
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(IJwtTokenService)} is not registered in the DI container. " +
+                    $"Call builder.Services.AddEasyReasyAuth(...) before {nameof(AddGoogleAuthEndpoint)}.");
+            }
+        }
+    }
+}

--- a/EasyReasy.Auth.Google/GoogleAuthOptions.cs
+++ b/EasyReasy.Auth.Google/GoogleAuthOptions.cs
@@ -1,0 +1,27 @@
+namespace EasyReasy.Auth.Google
+{
+    /// <summary>
+    /// Configuration options for Google authentication.
+    /// </summary>
+    public class GoogleAuthOptions
+    {
+        /// <summary>
+        /// The Google OAuth 2.0 client ID used to validate ID tokens.
+        /// </summary>
+        public required string ClientId { get; init; }
+
+        /// <summary>
+        /// An optional collection of allowed Google Workspace hosted domains.
+        /// When set, only users from these domains will be accepted. Matching is case-insensitive.
+        /// </summary>
+        public ICollection<string>? AllowedHostedDomains { get; init; }
+
+        /// <summary>
+        /// Whether to reject Google accounts whose email address is not verified (the token's
+        /// <c>email_verified</c> claim is false). Defaults to <c>true</c>, matching Google's guidance
+        /// that an unverified email must not be trusted as an identifier. Set to <c>false</c> only if
+        /// your application does not rely on the email address for identity.
+        /// </summary>
+        public bool RequireVerifiedEmail { get; init; } = true;
+    }
+}

--- a/EasyReasy.Auth.Google/GoogleAuthRequest.cs
+++ b/EasyReasy.Auth.Google/GoogleAuthRequest.cs
@@ -32,12 +32,13 @@ namespace EasyReasy.Auth.Google
         }
 
         /// <summary>
-        /// Returns a JSON string representation of this <see cref="GoogleAuthRequest"/> instance.
+        /// Returns a string representation of this <see cref="GoogleAuthRequest"/> instance
+        /// with the ID token redacted to prevent accidental secret leakage in logs.
         /// </summary>
-        /// <returns>A JSON string representation of this <see cref="GoogleAuthRequest"/> instance.</returns>
+        /// <returns>A string representation with the ID token replaced by "[REDACTED]".</returns>
         public override string ToString()
         {
-            return ToJson();
+            return "{\"idToken\":\"[REDACTED]\"}";
         }
 
         /// <summary>

--- a/EasyReasy.Auth.Google/GoogleAuthRequest.cs
+++ b/EasyReasy.Auth.Google/GoogleAuthRequest.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+using EasyReasy.Auth;
+
+namespace EasyReasy.Auth.Google
+{
+    /// <summary>
+    /// Request model for Google authentication containing the Google ID token.
+    /// </summary>
+    public class GoogleAuthRequest
+    {
+        /// <summary>
+        /// Gets the Google ID token to validate.
+        /// </summary>
+        public string IdToken { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GoogleAuthRequest"/> class.
+        /// </summary>
+        /// <param name="idToken">The Google ID token to validate.</param>
+        public GoogleAuthRequest(string idToken)
+        {
+            IdToken = idToken;
+        }
+
+        /// <summary>
+        /// Serializes this <see cref="GoogleAuthRequest"/> instance to a JSON string.
+        /// </summary>
+        /// <returns>A JSON string representation of this <see cref="GoogleAuthRequest"/> instance.</returns>
+        public string ToJson()
+        {
+            return JsonSerializer.Serialize(this, JsonSerializerSettings.CurrentOptions);
+        }
+
+        /// <summary>
+        /// Returns a JSON string representation of this <see cref="GoogleAuthRequest"/> instance.
+        /// </summary>
+        /// <returns>A JSON string representation of this <see cref="GoogleAuthRequest"/> instance.</returns>
+        public override string ToString()
+        {
+            return ToJson();
+        }
+
+        /// <summary>
+        /// Creates a <see cref="GoogleAuthRequest"/> instance from a JSON string.
+        /// </summary>
+        /// <param name="json">The JSON string to deserialize.</param>
+        /// <returns>A <see cref="GoogleAuthRequest"/> instance.</returns>
+        /// <exception cref="ArgumentException">Thrown when the JSON cannot be deserialized into a <see cref="GoogleAuthRequest"/>.</exception>
+        public static GoogleAuthRequest FromJson(string json)
+        {
+            try
+            {
+                GoogleAuthRequest? result = JsonSerializer.Deserialize<GoogleAuthRequest>(json, JsonSerializerSettings.CurrentOptions);
+
+                if (result == null)
+                {
+                    throw new ArgumentException($"Failed to deserialize {nameof(GoogleAuthRequest)} from the provided JSON.");
+                }
+
+                return result;
+            }
+            catch (JsonException jsonException)
+            {
+                throw new ArgumentException($"Failed to deserialize {nameof(GoogleAuthRequest)} from the provided JSON.", jsonException);
+            }
+        }
+    }
+}

--- a/EasyReasy.Auth.Google/GoogleAuthService.cs
+++ b/EasyReasy.Auth.Google/GoogleAuthService.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Http;
+
+namespace EasyReasy.Auth.Google
+{
+    /// <summary>
+    /// Internal orchestrator that validates a Google ID token and delegates to the
+    /// consumer-provided <see cref="IGoogleAuthHandler"/> to produce an <see cref="AuthResponse"/>,
+    /// surfacing the outcome as an <see cref="ExternalAuthResult"/> for audit logging.
+    /// </summary>
+    internal class GoogleAuthService
+    {
+        /// <summary>
+        /// The provider name recorded on every <see cref="ExternalAuthResult"/> this service produces.
+        /// </summary>
+        private const string ProviderName = "google";
+
+        private readonly IGoogleIdTokenValidator _tokenValidator;
+        private readonly IGoogleAuthHandler _handler;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GoogleAuthService"/> class.
+        /// </summary>
+        /// <param name="tokenValidator">The token validator for verifying Google ID tokens.</param>
+        /// <param name="handler">The consumer-provided handler for processing authenticated Google users.</param>
+        public GoogleAuthService(IGoogleIdTokenValidator tokenValidator, IGoogleAuthHandler handler)
+        {
+            _tokenValidator = tokenValidator;
+            _handler = handler;
+        }
+
+        /// <summary>
+        /// Validates the Google ID token and delegates to the handler to produce an auth response.
+        /// </summary>
+        /// <param name="idToken">The Google ID token to validate.</param>
+        /// <param name="jwtTokenService">The JWT token service for creating access tokens.</param>
+        /// <param name="refreshTokenService">The refresh token service, or null if not configured.</param>
+        /// <param name="httpContext">The HTTP context, or null.</param>
+        /// <returns>
+        /// An <see cref="ExternalAuthResult"/> describing the outcome: success with the issued
+        /// <see cref="AuthResponse"/>, <see cref="ExternalAuthFailureReason.InvalidToken"/> when the Google
+        /// token fails validation, or <see cref="ExternalAuthFailureReason.Rejected"/> when the handler
+        /// declines an otherwise-valid identity.
+        /// </returns>
+        public async Task<ExternalAuthResult> AuthenticateAsync(
+            string idToken,
+            IJwtTokenService jwtTokenService,
+            IRefreshTokenService? refreshTokenService,
+            HttpContext? httpContext)
+        {
+            if (string.IsNullOrWhiteSpace(idToken))
+            {
+                return ExternalAuthResult.Failed(ProviderName, ExternalAuthFailureReason.InvalidToken);
+            }
+
+            GoogleUserInfo userInfo;
+
+            try
+            {
+                userInfo = await _tokenValidator.ValidateAsync(idToken);
+            }
+            catch (GoogleTokenValidationException)
+            {
+                return ExternalAuthResult.Failed(ProviderName, ExternalAuthFailureReason.InvalidToken);
+            }
+
+            AuthResponse? authResponse = await _handler.HandleGoogleUserAsync(userInfo, jwtTokenService, refreshTokenService, httpContext);
+
+            if (authResponse == null)
+            {
+                return ExternalAuthResult.Failed(ProviderName, ExternalAuthFailureReason.Rejected, userInfo.Subject);
+            }
+
+            return ExternalAuthResult.Succeeded(ProviderName, authResponse, userInfo.Subject);
+        }
+    }
+}

--- a/EasyReasy.Auth.Google/GoogleAuthServiceCollectionExtensions.cs
+++ b/EasyReasy.Auth.Google/GoogleAuthServiceCollectionExtensions.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EasyReasy.Auth.Google
+{
+    /// <summary>
+    /// Extension methods for registering Google authentication services in the dependency injection container.
+    /// </summary>
+    public static class GoogleAuthServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registers the Google authentication services required for validating Google ID tokens
+        /// and handling Google sign-in requests.
+        /// The consumer must also register their own <see cref="IGoogleAuthHandler"/> implementation.
+        /// </summary>
+        /// <param name="services">The service collection to add Google auth services to.</param>
+        /// <param name="googleClientId">The Google OAuth 2.0 client ID used to validate ID tokens.</param>
+        /// <param name="allowedHostedDomains">
+        /// An optional collection of allowed Google Workspace hosted domains.
+        /// When set, only users from these domains will be accepted. Matching is case-insensitive.
+        /// </param>
+        /// <param name="requireVerifiedEmail">
+        /// Whether to reject Google accounts whose email address is not verified. Defaults to <c>true</c>,
+        /// matching Google's guidance that an unverified email must not be trusted as an identifier.
+        /// </param>
+        /// <returns>The service collection for chaining.</returns>
+        public static IServiceCollection AddEasyReasyGoogleAuth(
+            this IServiceCollection services,
+            string googleClientId,
+            ICollection<string>? allowedHostedDomains = null,
+            bool requireVerifiedEmail = true)
+        {
+            GoogleAuthOptions options = new GoogleAuthOptions
+            {
+                ClientId = googleClientId,
+                AllowedHostedDomains = allowedHostedDomains,
+                RequireVerifiedEmail = requireVerifiedEmail,
+            };
+
+            services.AddSingleton(options);
+            services.AddSingleton<IGoogleIdTokenValidator>(provider =>
+            {
+                GoogleAuthOptions registeredOptions = provider.GetRequiredService<GoogleAuthOptions>();
+                return new GoogleIdTokenValidator(registeredOptions);
+            });
+            services.AddScoped<GoogleAuthService>();
+
+            return services;
+        }
+    }
+}

--- a/EasyReasy.Auth.Google/GoogleAuthServiceCollectionExtensions.cs
+++ b/EasyReasy.Auth.Google/GoogleAuthServiceCollectionExtensions.cs
@@ -29,6 +29,8 @@ namespace EasyReasy.Auth.Google
             ICollection<string>? allowedHostedDomains = null,
             bool requireVerifiedEmail = true)
         {
+            ArgumentException.ThrowIfNullOrWhiteSpace(googleClientId);
+
             GoogleAuthOptions options = new GoogleAuthOptions
             {
                 ClientId = googleClientId,
@@ -37,11 +39,7 @@ namespace EasyReasy.Auth.Google
             };
 
             services.AddSingleton(options);
-            services.AddSingleton<IGoogleIdTokenValidator>(provider =>
-            {
-                GoogleAuthOptions registeredOptions = provider.GetRequiredService<GoogleAuthOptions>();
-                return new GoogleIdTokenValidator(registeredOptions);
-            });
+            services.AddSingleton<IGoogleIdTokenValidator, GoogleIdTokenValidator>();
             services.AddScoped<GoogleAuthService>();
 
             return services;

--- a/EasyReasy.Auth.Google/GoogleIdTokenValidator.cs
+++ b/EasyReasy.Auth.Google/GoogleIdTokenValidator.cs
@@ -65,6 +65,11 @@ namespace EasyReasy.Auth.Google
                 }
             }
 
+            if (string.IsNullOrEmpty(payload.Email))
+            {
+                throw new GoogleTokenValidationException("The Google ID token does not contain an email address.");
+            }
+
             if (options.RequireVerifiedEmail && !payload.EmailVerified)
             {
                 throw new GoogleTokenValidationException("The Google account's email address is not verified.");

--- a/EasyReasy.Auth.Google/GoogleIdTokenValidator.cs
+++ b/EasyReasy.Auth.Google/GoogleIdTokenValidator.cs
@@ -1,0 +1,83 @@
+using Google.Apis.Auth;
+
+namespace EasyReasy.Auth.Google
+{
+    /// <summary>
+    /// Default implementation of <see cref="IGoogleIdTokenValidator"/> that uses
+    /// Google's <see cref="GoogleJsonWebSignature"/> to validate ID tokens.
+    /// </summary>
+    internal class GoogleIdTokenValidator : IGoogleIdTokenValidator
+    {
+        private readonly GoogleAuthOptions _options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GoogleIdTokenValidator"/> class.
+        /// </summary>
+        /// <param name="options">The Google authentication options containing the client ID and allowed domains.</param>
+        public GoogleIdTokenValidator(GoogleAuthOptions options)
+        {
+            _options = options;
+        }
+
+        /// <inheritdoc />
+        public async Task<GoogleUserInfo> ValidateAsync(string idToken)
+        {
+            GoogleJsonWebSignature.ValidationSettings validationSettings = new GoogleJsonWebSignature.ValidationSettings
+            {
+                Audience = new string[] { _options.ClientId },
+            };
+
+            GoogleJsonWebSignature.Payload payload;
+
+            try
+            {
+                payload = await GoogleJsonWebSignature.ValidateAsync(idToken, validationSettings);
+            }
+            catch (InvalidJwtException exception)
+            {
+                throw new GoogleTokenValidationException("Google ID token validation failed.", exception);
+            }
+
+            return ValidatePolicyAndBuildUserInfo(payload, _options);
+        }
+
+        /// <summary>
+        /// Applies the post-validation policy (hosted-domain allowlist and email-verification requirement)
+        /// to an already-validated Google payload and maps it to a <see cref="GoogleUserInfo"/>. Kept separate
+        /// from the network-bound token validation so the policy is unit-testable in isolation.
+        /// </summary>
+        /// <param name="payload">The validated Google ID token payload.</param>
+        /// <param name="options">The Google authentication options.</param>
+        /// <returns>The mapped <see cref="GoogleUserInfo"/>.</returns>
+        /// <exception cref="GoogleTokenValidationException">
+        /// Thrown when the hosted domain is not in the allowlist, or when
+        /// <see cref="GoogleAuthOptions.RequireVerifiedEmail"/> is set and the account's email is not verified.
+        /// </exception>
+        internal static GoogleUserInfo ValidatePolicyAndBuildUserInfo(GoogleJsonWebSignature.Payload payload, GoogleAuthOptions options)
+        {
+            if (options.AllowedHostedDomains != null && options.AllowedHostedDomains.Count > 0)
+            {
+                if (payload.HostedDomain == null
+                    || !options.AllowedHostedDomains.Any(domain => string.Equals(domain, payload.HostedDomain, StringComparison.OrdinalIgnoreCase)))
+                {
+                    throw new GoogleTokenValidationException(
+                        $"The hosted domain '{payload.HostedDomain}' is not in the list of allowed hosted domains.");
+                }
+            }
+
+            if (options.RequireVerifiedEmail && !payload.EmailVerified)
+            {
+                throw new GoogleTokenValidationException("The Google account's email address is not verified.");
+            }
+
+            return new GoogleUserInfo
+            {
+                Subject = payload.Subject,
+                Email = payload.Email,
+                EmailVerified = payload.EmailVerified,
+                Name = payload.Name,
+                PictureUrl = payload.Picture,
+            };
+        }
+    }
+}

--- a/EasyReasy.Auth.Google/GoogleTokenValidationException.cs
+++ b/EasyReasy.Auth.Google/GoogleTokenValidationException.cs
@@ -1,0 +1,29 @@
+namespace EasyReasy.Auth.Google
+{
+    /// <summary>
+    /// Exception thrown when a Google ID token fails validation.
+    /// This includes invalid signatures, expired tokens, audience mismatches,
+    /// and hosted domain rejections.
+    /// </summary>
+    public class GoogleTokenValidationException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GoogleTokenValidationException"/> class.
+        /// </summary>
+        /// <param name="message">The message describing the validation failure.</param>
+        public GoogleTokenValidationException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GoogleTokenValidationException"/> class.
+        /// </summary>
+        /// <param name="message">The message describing the validation failure.</param>
+        /// <param name="innerException">The inner exception that caused the validation failure.</param>
+        public GoogleTokenValidationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/EasyReasy.Auth.Google/GoogleUserInfo.cs
+++ b/EasyReasy.Auth.Google/GoogleUserInfo.cs
@@ -1,0 +1,34 @@
+namespace EasyReasy.Auth.Google
+{
+    /// <summary>
+    /// Contains user information extracted from a validated Google ID token.
+    /// </summary>
+    public class GoogleUserInfo
+    {
+        /// <summary>
+        /// Google's stable unique identifier for the user (the "sub" claim).
+        /// </summary>
+        public required string Subject { get; init; }
+
+        /// <summary>
+        /// The user's email address.
+        /// </summary>
+        public required string Email { get; init; }
+
+        /// <summary>
+        /// Whether Google has verified that the user owns this email address (the token's
+        /// <c>email_verified</c> claim). An unverified email must not be trusted as an identifier.
+        /// </summary>
+        public required bool EmailVerified { get; init; }
+
+        /// <summary>
+        /// The user's display name, or null if not provided.
+        /// </summary>
+        public string? Name { get; init; }
+
+        /// <summary>
+        /// The URL of the user's profile picture, or null if not provided.
+        /// </summary>
+        public string? PictureUrl { get; init; }
+    }
+}

--- a/EasyReasy.Auth.Google/IGoogleAuthHandler.cs
+++ b/EasyReasy.Auth.Google/IGoogleAuthHandler.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Http;
+
+namespace EasyReasy.Auth.Google
+{
+    /// <summary>
+    /// Consumer-implemented interface for handling authenticated Google users.
+    /// This is the integration point where the consuming application decides how to
+    /// handle a verified Google identity (e.g., find or create the user, assign claims/roles,
+    /// and issue a JWT).
+    /// </summary>
+    public interface IGoogleAuthHandler
+    {
+        /// <summary>
+        /// Handles an authenticated Google user by looking up or creating the user
+        /// and returning an <see cref="AuthResponse"/> with a JWT token.
+        /// </summary>
+        /// <param name="userInfo">The validated Google user information.</param>
+        /// <param name="jwtTokenService">The JWT token service for creating access tokens.</param>
+        /// <param name="refreshTokenService">The refresh token service, or null if refresh tokens are not configured.</param>
+        /// <param name="httpContext">The HTTP context containing request information, or null.</param>
+        /// <returns>An <see cref="AuthResponse"/> if the user is accepted, or null to reject the request.</returns>
+        Task<AuthResponse?> HandleGoogleUserAsync(
+            GoogleUserInfo userInfo,
+            IJwtTokenService jwtTokenService,
+            IRefreshTokenService? refreshTokenService,
+            HttpContext? httpContext = null);
+    }
+}

--- a/EasyReasy.Auth.Google/IGoogleIdTokenValidator.cs
+++ b/EasyReasy.Auth.Google/IGoogleIdTokenValidator.cs
@@ -1,0 +1,17 @@
+namespace EasyReasy.Auth.Google
+{
+    /// <summary>
+    /// Validates a Google ID token and extracts user information.
+    /// This is an internal testability seam wrapping Google's static validation API.
+    /// </summary>
+    internal interface IGoogleIdTokenValidator
+    {
+        /// <summary>
+        /// Validates the specified Google ID token and returns the extracted user information.
+        /// </summary>
+        /// <param name="idToken">The Google ID token to validate.</param>
+        /// <returns>The validated user information.</returns>
+        /// <exception cref="GoogleTokenValidationException">Thrown when the token is invalid or validation fails.</exception>
+        Task<GoogleUserInfo> ValidateAsync(string idToken);
+    }
+}

--- a/EasyReasy.Auth.Google/README.md
+++ b/EasyReasy.Auth.Google/README.md
@@ -1,0 +1,157 @@
+# EasyReasy.Auth.Google
+
+Google Sign-In integration for the EasyReasy.Auth JWT authentication pipeline. Validates Google ID tokens and lets your application issue the same JWTs (and optional refresh tokens) as any other auth method.
+
+## Quick Start
+
+### 1. Install
+
+```bash
+dotnet add package EasyReasy.Auth.Google
+```
+
+### 2. Implement `IGoogleAuthHandler`
+
+This is where you decide what happens after a Google user is verified - look them up, create them, assign claims and roles, and build the JWT:
+
+```csharp
+public class MyGoogleAuthHandler : IGoogleAuthHandler
+{
+    private readonly IUserRepository _users;
+
+    public MyGoogleAuthHandler(IUserRepository users)
+    {
+        _users = users;
+    }
+
+    public async Task<AuthResponse?> HandleGoogleUserAsync(
+        GoogleUserInfo userInfo,
+        IJwtTokenService jwtTokenService,
+        IRefreshTokenService? refreshTokenService,
+        HttpContext? httpContext)
+    {
+        User user = await _users.FindOrCreateByGoogleSubjectAsync(
+            userInfo.Subject, userInfo.Email, userInfo.Name);
+
+        DateTime expiresAt = DateTime.UtcNow.AddHours(1);
+        string token = jwtTokenService.CreateToken(
+            subject: user.Id.ToString(),
+            authType: "user",
+            additionalClaims: [],
+            roles: user.Roles,
+            expiresAt: expiresAt);
+
+        string? refreshToken = null;
+        if (refreshTokenService != null)
+        {
+            refreshToken = await refreshTokenService.CreateRefreshTokenAsync(
+                user.Id.ToString(), "user", null, null);
+        }
+
+        return new AuthResponse(token, expiresAt.ToString("o"), refreshToken);
+    }
+}
+```
+
+### 3. Register Services
+
+```csharp
+// In Program.cs
+builder.Services.AddEasyReasyAuth(jwtSecret);
+builder.Services.AddEasyReasyGoogleAuth(googleClientId: "your-client-id.apps.googleusercontent.com");
+builder.Services.AddScoped<IGoogleAuthHandler, MyGoogleAuthHandler>();
+
+var app = builder.Build();
+
+app.UseEasyReasyAuth();
+app.AddGoogleAuthEndpoint();   // POST /api/auth/google
+app.AddAuthEndpoints();        // existing username/password + API key endpoints
+```
+
+## Flow
+
+1. Frontend uses Google's JavaScript SDK - user consents - frontend gets a Google ID token
+2. Frontend sends `POST /api/auth/google` with `{ "idToken": "..." }`
+3. Library validates the ID token against Google's public keys
+4. Library enforces the hosted-domain allowlist and email-verification policy, then extracts `GoogleUserInfo` (subject, email, email-verified, name, picture URL)
+5. Library calls your `IGoogleAuthHandler.HandleGoogleUserAsync`
+6. You look up or create the user, issue a JWT via `IJwtTokenService`, optionally create a refresh token
+7. `AuthResponse` (token, expiration, optional refresh token) is returned to the frontend
+
+## Configuration
+
+### Restrict to Google Workspace Domains
+
+```csharp
+builder.Services.AddEasyReasyGoogleAuth(
+    googleClientId: "your-client-id.apps.googleusercontent.com",
+    allowedHostedDomains: new[] { "yourcompany.com" });
+```
+
+When `allowedHostedDomains` is set, only users whose Google account belongs to one of those domains will be accepted. All other tokens are rejected. Domain matching is case-insensitive.
+
+### Email Verification
+
+By default, accounts whose email address is not verified by Google (the token's `email_verified` claim is `false`) are rejected, matching Google's guidance that an unverified email must not be trusted as an identifier. If your application does not rely on the email address for identity, opt out:
+
+```csharp
+builder.Services.AddEasyReasyGoogleAuth(
+    googleClientId: "your-client-id.apps.googleusercontent.com",
+    requireVerifiedEmail: false);
+```
+
+Either way, the verification state is exposed on `GoogleUserInfo.EmailVerified` so your `IGoogleAuthHandler` can make its own decision.
+
+## Endpoint Behavior
+
+`AddGoogleAuthEndpoint` maps `POST /api/auth/google` with the same hardening as the built-in EasyReasy.Auth endpoints:
+
+- It is **anonymous**, so it stays reachable even when the application applies a global authorization policy.
+- It sets **`Cache-Control: no-store`**, so the issued token is never cached by browsers or proxies.
+
+## Audit Logging
+
+Google sign-in flows into the same audit pipeline as every other EasyReasy.Auth event. If you register an `IAuthAuditLogger` (see the EasyReasy.Auth README, "Security Audit Logging"), the endpoint invokes `OnExternalAuthAsync` after every attempt — success or failure — before the response is written:
+
+```csharp
+public class MyAuditLogger : IAuthAuditLogger
+{
+    private readonly ILogger<MyAuditLogger> _logger;
+
+    public MyAuditLogger(ILogger<MyAuditLogger> logger) { _logger = logger; }
+
+    public Task OnExternalAuthAsync(HttpContext ctx, ExternalAuthResult result)
+    {
+        _logger.LogInformation(
+            "auth.external {Provider} {Outcome} subject={Subject} reason={Reason} ip={Ip}",
+            result.Provider,                                  // "google"
+            result.Success ? "success" : "failure",
+            result.AttemptedSubject,
+            result.FailureReason,
+            ctx.Connection.RemoteIpAddress);
+        return Task.CompletedTask;
+    }
+}
+```
+
+The `ExternalAuthResult.FailureReason` is `InvalidToken` when the Google ID token fails validation (bad signature, expiry, audience mismatch, or a disallowed hosted domain) and `Rejected` when your `IGoogleAuthHandler` returns `null` to decline an otherwise-valid identity. As with the other result types, log the **metadata** shown above — never the whole result, because on success it embeds the issued bearer token.
+
+## Models
+
+### `GoogleUserInfo`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Subject` | `string` (required) | Google's stable unique user ID (the `sub` claim) |
+| `Email` | `string` (required) | The user's email address |
+| `EmailVerified` | `bool` (required) | Whether Google has verified the user owns this email (the `email_verified` claim) |
+| `Name` | `string?` | Display name, or null |
+| `PictureUrl` | `string?` | Profile picture URL, or null |
+
+### `GoogleAuthRequest`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `IdToken` | `string` | The Google ID token from the frontend |
+
+Follows the standard EasyReasy serialization pattern: `ToJson()`, `FromJson(string)`, `ToString()`.

--- a/EasyReasy.Auth.Google/README.md
+++ b/EasyReasy.Auth.Google/README.md
@@ -61,7 +61,7 @@ builder.Services.AddEasyReasyAuth(jwtSecret);
 builder.Services.AddEasyReasyGoogleAuth(googleClientId: "your-client-id.apps.googleusercontent.com");
 builder.Services.AddScoped<IGoogleAuthHandler, MyGoogleAuthHandler>();
 
-var app = builder.Build();
+WebApplication app = builder.Build();
 
 app.UseEasyReasyAuth();
 app.AddGoogleAuthEndpoint();   // POST /api/auth/google
@@ -134,7 +134,7 @@ public class MyAuditLogger : IAuthAuditLogger
 }
 ```
 
-The `ExternalAuthResult.FailureReason` is `InvalidToken` when the Google ID token fails validation (bad signature, expiry, audience mismatch, or a disallowed hosted domain) and `Rejected` when your `IGoogleAuthHandler` returns `null` to decline an otherwise-valid identity. As with the other result types, log the **metadata** shown above — never the whole result, because on success it embeds the issued bearer token.
+The `ExternalAuthResult.FailureReason` is `InvalidToken` when the Google ID token fails validation (bad signature, expiry, audience mismatch, a disallowed hosted domain, or an unverified email) and `Rejected` when your `IGoogleAuthHandler` returns `null` to decline an otherwise-valid identity. As with the other result types, log the **metadata** shown above — never the whole result, because on success it embeds the issued bearer token.
 
 ## Models
 

--- a/EasyReasy.Auth.Google/README.md
+++ b/EasyReasy.Auth.Google/README.md
@@ -65,7 +65,7 @@ WebApplication app = builder.Build();
 
 app.UseEasyReasyAuth();
 app.AddGoogleAuthEndpoint();   // POST /api/auth/google
-app.AddAuthEndpoints();        // existing username/password + API key endpoints
+app.AddAuthEndpoints();        // the built-in EasyReasy.Auth endpoints (login, refresh, logout)
 ```
 
 ## Flow

--- a/EasyReasy.Auth.Tests/AuthAuditLoggerDiTests.cs
+++ b/EasyReasy.Auth.Tests/AuthAuditLoggerDiTests.cs
@@ -64,10 +64,12 @@ namespace EasyReasy.Auth.Tests
 
             Assert.IsTrue(asInterface.OnLoginAsync(httpContext, LoginResult.Failed(LoginFailureReason.InvalidCredentials)).IsCompletedSuccessfully);
             Assert.IsTrue(asInterface.OnApiKeyAuthAsync(httpContext, ApiKeyAuthResult.Failed(ApiKeyAuthFailureReason.UnknownKey)).IsCompletedSuccessfully);
+            Assert.IsTrue(asInterface.OnExternalAuthAsync(httpContext, ExternalAuthResult.Failed("google", ExternalAuthFailureReason.InvalidToken)).IsCompletedSuccessfully);
             Assert.IsTrue(asInterface.OnRefreshAsync(httpContext, RefreshResult.Failed(RefreshFailureReason.TokenExpired)).IsCompletedSuccessfully);
             Assert.IsTrue(asInterface.OnLogoutAsync(httpContext, LogoutResult.Unknown()).IsCompletedSuccessfully);
             Assert.IsTrue(asInterface.OnSessionsInvalidatedAsync(new SessionRevocationResult("user-1", 0)).IsCompletedSuccessfully);
             Assert.IsTrue(asInterface.OnConcurrentSessionsRevokedAsync(new SessionRevocationResult("user-1", 0)).IsCompletedSuccessfully);
+            Assert.IsTrue(asInterface.OnSessionSupersededAsync(httpContext, new FamilyRetirementResult { FamilyId = "family-1" }).IsCompletedSuccessfully);
         }
 
         private sealed class MinimalAuditLogger : IAuthAuditLogger

--- a/EasyReasy.Auth.Tests/ExternalAuthResultTests.cs
+++ b/EasyReasy.Auth.Tests/ExternalAuthResultTests.cs
@@ -1,0 +1,56 @@
+namespace EasyReasy.Auth.Tests
+{
+    [TestClass]
+    public class ExternalAuthResultTests
+    {
+        [TestMethod]
+        public void Succeeded_ShouldCreateSuccessfulResult()
+        {
+            AuthResponse authResponse = new AuthResponse("jwt-token", "2025-01-01T00:00:00Z");
+
+            ExternalAuthResult result = ExternalAuthResult.Succeeded("google", authResponse, "user-42");
+
+            Assert.AreEqual("google", result.Provider);
+            Assert.IsTrue(result.Success);
+            Assert.AreSame(authResponse, result.AuthResponse);
+            Assert.AreEqual("user-42", result.AttemptedSubject);
+            Assert.IsNull(result.FailureReason);
+        }
+
+        [TestMethod]
+        public void Failed_ShouldCreateFailedResult()
+        {
+            ExternalAuthResult result = ExternalAuthResult.Failed("google", ExternalAuthFailureReason.InvalidToken);
+
+            Assert.AreEqual("google", result.Provider);
+            Assert.IsFalse(result.Success);
+            Assert.IsNull(result.AuthResponse);
+            Assert.AreEqual(ExternalAuthFailureReason.InvalidToken, result.FailureReason);
+        }
+
+        [TestMethod]
+        public void Failed_WithoutAttemptedSubject_ShouldDefaultToNull()
+        {
+            ExternalAuthResult result = ExternalAuthResult.Failed("google", ExternalAuthFailureReason.InvalidToken);
+
+            Assert.IsNull(result.AttemptedSubject);
+        }
+
+        [TestMethod]
+        public void Failed_WithAttemptedSubject_ShouldPopulateIt()
+        {
+            ExternalAuthResult result = ExternalAuthResult.Failed("google", ExternalAuthFailureReason.Rejected, attemptedSubject: "sub-99");
+
+            Assert.AreEqual("sub-99", result.AttemptedSubject);
+            Assert.AreEqual(ExternalAuthFailureReason.Rejected, result.FailureReason);
+        }
+
+        [TestMethod]
+        public void Failed_WithEachReason_ShouldSetReasonCorrectly()
+        {
+            Assert.AreEqual(ExternalAuthFailureReason.InvalidToken, ExternalAuthResult.Failed("google", ExternalAuthFailureReason.InvalidToken).FailureReason);
+            Assert.AreEqual(ExternalAuthFailureReason.Rejected, ExternalAuthResult.Failed("google", ExternalAuthFailureReason.Rejected).FailureReason);
+            Assert.AreEqual(ExternalAuthFailureReason.Other, ExternalAuthResult.Failed("google", ExternalAuthFailureReason.Other).FailureReason);
+        }
+    }
+}

--- a/EasyReasy.Auth.Tests/RecordingAuditLogger.cs
+++ b/EasyReasy.Auth.Tests/RecordingAuditLogger.cs
@@ -10,6 +10,7 @@ namespace EasyReasy.Auth.Tests
     {
         public List<(HttpContext HttpContext, LoginResult Result)> LoginCalls { get; } = new List<(HttpContext, LoginResult)>();
         public List<(HttpContext HttpContext, ApiKeyAuthResult Result)> ApiKeyCalls { get; } = new List<(HttpContext, ApiKeyAuthResult)>();
+        public List<(HttpContext HttpContext, ExternalAuthResult Result)> ExternalAuthCalls { get; } = new List<(HttpContext, ExternalAuthResult)>();
         public List<(HttpContext? HttpContext, RefreshResult Result)> RefreshCalls { get; } = new List<(HttpContext?, RefreshResult)>();
         public List<(HttpContext? HttpContext, LogoutResult Result)> LogoutCalls { get; } = new List<(HttpContext?, LogoutResult)>();
         public List<SessionRevocationResult> SessionsInvalidatedCalls { get; } = new List<SessionRevocationResult>();
@@ -25,6 +26,12 @@ namespace EasyReasy.Auth.Tests
         public Task OnApiKeyAuthAsync(HttpContext httpContext, ApiKeyAuthResult result)
         {
             ApiKeyCalls.Add((httpContext, result));
+            return Task.CompletedTask;
+        }
+
+        public Task OnExternalAuthAsync(HttpContext httpContext, ExternalAuthResult result)
+        {
+            ExternalAuthCalls.Add((httpContext, result));
             return Task.CompletedTask;
         }
 

--- a/EasyReasy.Auth/ExternalAuthFailureReason.cs
+++ b/EasyReasy.Auth/ExternalAuthFailureReason.cs
@@ -1,0 +1,27 @@
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// Represents the reason an external identity-provider authentication attempt failed
+    /// (for example a Google, Apple, or Microsoft sign-in). Intended to flow into audit logs
+    /// (ISO 27001 A.12.4.1 records of failed authentication attempts) — never returned to the client.
+    /// </summary>
+    public enum ExternalAuthFailureReason
+    {
+        /// <summary>
+        /// The identity-provider token did not validate — for example an invalid signature, an expired
+        /// token, an audience mismatch, or an identity whose hosted domain/tenant is not allowed.
+        /// </summary>
+        InvalidToken,
+
+        /// <summary>
+        /// The token validated and the identity is genuine, but the application declined it — for example
+        /// the user is not provisioned, or is administratively disabled.
+        /// </summary>
+        Rejected,
+
+        /// <summary>
+        /// The attempt failed for a reason that does not fit the other categories.
+        /// </summary>
+        Other,
+    }
+}

--- a/EasyReasy.Auth/ExternalAuthResult.cs
+++ b/EasyReasy.Auth/ExternalAuthResult.cs
@@ -1,0 +1,87 @@
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// Represents the result of an external identity-provider authentication attempt
+    /// (for example a Google, Apple, or Microsoft sign-in). Use the static factory methods
+    /// <see cref="Succeeded"/> and <see cref="Failed"/> to create instances.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately does not carry the raw provider token, so that consumer code logging the whole result
+    /// cannot accidentally leak a credential. On the success path the embedded <see cref="AuthResponse"/>
+    /// still carries the issued JWT and (when refresh tokens are enabled) the raw refresh token — see the
+    /// remarks on <see cref="IAuthAuditLogger"/> for safe-logging guidance.
+    /// </remarks>
+    public sealed class ExternalAuthResult
+    {
+        /// <summary>
+        /// The identity provider that handled the attempt, in lower case (for example <c>"google"</c>).
+        /// </summary>
+        public string Provider { get; }
+
+        /// <summary>
+        /// Whether the authentication attempt succeeded.
+        /// </summary>
+        public bool Success { get; }
+
+        /// <summary>
+        /// The authentication response containing the access token and (optionally) a refresh token.
+        /// Only populated when <see cref="Success"/> is true.
+        /// </summary>
+        public AuthResponse? AuthResponse { get; }
+
+        /// <summary>
+        /// The subject identifier associated with the attempt — the provider's stable user id — when known.
+        /// Populated on success, and on failure when the identity validated but was then rejected. Null when
+        /// the provider token itself failed to validate, because no trustworthy subject is available.
+        /// </summary>
+        public string? AttemptedSubject { get; }
+
+        /// <summary>
+        /// The reason the attempt failed.
+        /// Only populated when <see cref="Success"/> is false.
+        /// </summary>
+        public ExternalAuthFailureReason? FailureReason { get; }
+
+        private ExternalAuthResult(
+            string provider,
+            bool success,
+            AuthResponse? authResponse,
+            string? attemptedSubject,
+            ExternalAuthFailureReason? failureReason)
+        {
+            Provider = provider;
+            Success = success;
+            AuthResponse = authResponse;
+            AttemptedSubject = attemptedSubject;
+            FailureReason = failureReason;
+        }
+
+        /// <summary>
+        /// Creates a successful external authentication result.
+        /// </summary>
+        /// <param name="provider">The identity provider that authenticated the user (for example <c>"google"</c>).</param>
+        /// <param name="authResponse">The authentication response containing the access token.</param>
+        /// <param name="subject">The subject identifier (the provider's stable user id) that was authenticated.</param>
+        /// <returns>A successful <see cref="ExternalAuthResult"/>.</returns>
+        public static ExternalAuthResult Succeeded(string provider, AuthResponse authResponse, string subject)
+        {
+            return new ExternalAuthResult(provider, true, authResponse, subject, null);
+        }
+
+        /// <summary>
+        /// Creates a failed external authentication result.
+        /// </summary>
+        /// <param name="provider">The identity provider that handled the attempt (for example <c>"google"</c>).</param>
+        /// <param name="reason">The reason the attempt failed.</param>
+        /// <param name="attemptedSubject">
+        /// The subject identifier that was attempted, when available. Populate it when the provider token
+        /// validated but the identity was then rejected; leave it <c>null</c> when the token itself failed
+        /// to validate and no trustworthy subject exists.
+        /// </param>
+        /// <returns>A failed <see cref="ExternalAuthResult"/>.</returns>
+        public static ExternalAuthResult Failed(string provider, ExternalAuthFailureReason reason, string? attemptedSubject = null)
+        {
+            return new ExternalAuthResult(provider, false, null, attemptedSubject, reason);
+        }
+    }
+}

--- a/EasyReasy.Auth/IAuthAuditLogger.cs
+++ b/EasyReasy.Auth/IAuthAuditLogger.cs
@@ -33,11 +33,12 @@ namespace EasyReasy.Auth
     /// <b>Hook placement</b>:
     /// <see cref="OnRefreshAsync"/>, <see cref="OnLogoutAsync"/>, and <see cref="OnSessionsInvalidatedAsync"/> are invoked
     /// from inside <see cref="RefreshTokenService"/>, so both HTTP-endpoint and programmatic callers trigger the hook.
-    /// <see cref="OnLoginAsync"/> and <see cref="OnApiKeyAuthAsync"/> are invoked from the HTTP endpoint layer only, because
-    /// the underlying <see cref="IAuthRequestValidationService"/> is consumer-implemented and cannot be guaranteed to call
-    /// the audit logger itself. Consumers who validate credentials outside the HTTP endpoint flow can resolve
-    /// <see cref="IAuthAuditLogger"/> from DI and invoke <see cref="OnLoginAsync"/> / <see cref="OnApiKeyAuthAsync"/>
-    /// themselves — the library's endpoint code uses the interface exactly the same way.
+    /// <see cref="OnLoginAsync"/>, <see cref="OnApiKeyAuthAsync"/>, and <see cref="OnExternalAuthAsync"/> are invoked from
+    /// the HTTP endpoint layer only (the last from a provider integration package such as <c>EasyReasy.Auth.Google</c>),
+    /// because the underlying credential validation is consumer-implemented and cannot be guaranteed to call the audit
+    /// logger itself. Consumers who authenticate outside the built-in HTTP endpoint flow can resolve
+    /// <see cref="IAuthAuditLogger"/> from DI and invoke these hooks themselves — the library's endpoint code uses the
+    /// interface exactly the same way.
     /// </para>
     /// <para>
     /// <b>Default-interface-method caveat</b>: the no-op defaults only resolve when a method is invoked through the
@@ -64,6 +65,22 @@ namespace EasyReasy.Auth
         /// <param name="httpContext">The HTTP context of the request that triggered the event.</param>
         /// <param name="result">The structured result of the API key validation.</param>
         Task OnApiKeyAuthAsync(HttpContext httpContext, ApiKeyAuthResult result) => Task.CompletedTask;
+
+        /// <summary>
+        /// Invoked after an external identity-provider authentication attempt (for example a Google sign-in).
+        /// <paramref name="result"/> carries success state, the <see cref="ExternalAuthResult.Provider"/> name,
+        /// the attempted subject, and (on failure) an <see cref="ExternalAuthFailureReason"/>.
+        /// </summary>
+        /// <remarks>
+        /// Like <see cref="OnLoginAsync"/> and <see cref="OnApiKeyAuthAsync"/>, this hook is invoked from the
+        /// HTTP endpoint layer — here, a provider integration package's endpoint (such as
+        /// <c>EasyReasy.Auth.Google</c>'s <c>AddGoogleAuthEndpoint</c>) — rather than from inside the core
+        /// services, because the identity decision is made by consumer-supplied code that the core cannot
+        /// guarantee will call the logger itself.
+        /// </remarks>
+        /// <param name="httpContext">The HTTP context of the request that triggered the event.</param>
+        /// <param name="result">The structured result of the external authentication attempt.</param>
+        Task OnExternalAuthAsync(HttpContext httpContext, ExternalAuthResult result) => Task.CompletedTask;
 
         /// <summary>
         /// Invoked after a refresh token operation. <paramref name="result"/> carries success state,

--- a/EasyReasy.Auth/README.md
+++ b/EasyReasy.Auth/README.md
@@ -609,12 +609,13 @@ await _refreshTokenService.RetireFamilyAsync(priorFamilyId, HttpContext.GetUserI
 
 ### 10. Security Audit Logging (ISO 27001 A.9 / A.12)
 
-Every authentication event the library surfaces — success or failure — is reported through a single optional DI service: `IAuthAuditLogger`. Register an implementation and the built-in endpoints (plus the programmatic triggers `RefreshTokenService.InvalidateAllSessionsAsync` and single-session enforcement on login) will invoke it with a structured result object.
+Every authentication event the library surfaces — success or failure — is reported through a single optional DI service: `IAuthAuditLogger`. Register an implementation and the built-in endpoints (plus the programmatic triggers `RefreshTokenService.InvalidateAllSessionsAsync` and single-session enforcement on login) will invoke it with a structured result object. Provider integration packages route through the same service: the `EasyReasy.Auth.Google` sign-in endpoint invokes `OnExternalAuthAsync`, so external sign-ins land in the same audit sink as everything else.
 
 | Event | Hook | Control | Typical data to log |
 |---|---|---|---|
 | Successful / failed username+password login | `OnLoginAsync(httpContext, LoginResult)` | ISO 27001 A.12.4.1 | outcome, `AttemptedSubject`, `FailureReason`, IP, User-Agent, time |
 | Successful / failed API key auth | `OnApiKeyAuthAsync(httpContext, ApiKeyAuthResult)` | ISO 27001 A.12.4.1 | outcome, `AttemptedClientId`, `FailureReason`, IP, User-Agent, time |
+| Successful / failed external identity-provider sign-in (e.g. Google) | `OnExternalAuthAsync(httpContext, ExternalAuthResult)` | ISO 27001 A.12.4.1 | outcome, `Provider`, `AttemptedSubject`, `FailureReason`, IP, User-Agent, time |
 | Refresh (incl. `TheftDetected`, `DeniedByResolver`, `ResolverError`) | `OnRefreshAsync(httpContext, RefreshResult)` | ISO 27001 A.12.4.1 | outcome, `Subject`, `FamilyId`, `FailureReason`, IP, time |
 | Logout | `OnLogoutAsync(httpContext, LogoutResult)` | ISO 27001 A.9.2.6 | `WasKnown`, `Subject`, `FamilyId`, IP, time |
 | Bulk session revocation | `OnSessionsInvalidatedAsync(SessionRevocationResult)` | ISO 27001 A.9.2.6 | `Subject`, `InvalidatedFamilyCount`, time |
@@ -623,7 +624,7 @@ Every authentication event the library surfaces — success or failure — is re
 
 All methods have default no-op implementations — implement only the events you care about. The result objects deliberately never carry a raw password or a raw API key, so failure records are safe to serialise to your log store.
 
-⚠️ **Do not serialise the whole result object on the success path.** `LoginResult` and `ApiKeyAuthResult` embed an `AuthResponse` that carries the issued JWT access token and (when refresh tokens are enabled) the raw refresh token — both are bearer credentials. Log **metadata** from the result (`Success`, `AttemptedSubject` / `AttemptedClientId`, `FailureReason`) — never log `result.AuthResponse` with a structured logger's destructuring syntax (e.g. Serilog `{@result}`) or `JsonSerializer.Serialize(result)`. The example below follows the right pattern.
+⚠️ **Do not serialise the whole result object on the success path.** `LoginResult`, `ApiKeyAuthResult`, and `ExternalAuthResult` embed an `AuthResponse` that carries the issued JWT access token and (when refresh tokens are enabled) the raw refresh token — both are bearer credentials. Log **metadata** from the result (`Success`, `AttemptedSubject` / `AttemptedClientId`, `FailureReason`) — never log `result.AuthResponse` with a structured logger's destructuring syntax (e.g. Serilog `{@result}`) or `JsonSerializer.Serialize(result)`. The example below follows the right pattern.
 
 ```csharp
 public class MyAuditLogger : IAuthAuditLogger

--- a/EasyReasy.sln
+++ b/EasyReasy.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34408.163

--- a/EasyReasy.sln
+++ b/EasyReasy.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34408.163
@@ -26,6 +26,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyReasy.Auth.Client", "EasyReasy.Auth.Client\EasyReasy.Auth.Client.csproj", "{A9D59EAC-53D7-4433-BE4D-30B9C9253E8F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyReasy.Auth.Client.Tests", "EasyReasy.Auth.Client.Tests\EasyReasy.Auth.Client.Tests.csproj", "{293AA1B4-E783-41A3-8FE5-86D8D3C03F59}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyReasy.Auth.Google", "EasyReasy.Auth.Google\EasyReasy.Auth.Google.csproj", "{B36D9172-4196-4300-967A-294C3D8532DD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyReasy.Auth.Google.Tests", "EasyReasy.Auth.Google.Tests\EasyReasy.Auth.Google.Tests.csproj", "{10330461-3F68-4DED-BB54-294788B72254}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,6 +85,14 @@ Global
 		{293AA1B4-E783-41A3-8FE5-86D8D3C03F59}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{293AA1B4-E783-41A3-8FE5-86D8D3C03F59}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{293AA1B4-E783-41A3-8FE5-86D8D3C03F59}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B36D9172-4196-4300-967A-294C3D8532DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B36D9172-4196-4300-967A-294C3D8532DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B36D9172-4196-4300-967A-294C3D8532DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B36D9172-4196-4300-967A-294C3D8532DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{10330461-3F68-4DED-BB54-294788B72254}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{10330461-3F68-4DED-BB54-294788B72254}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{10330461-3F68-4DED-BB54-294788B72254}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{10330461-3F68-4DED-BB54-294788B72254}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ As the system grew, **EasyReasy.ByteShelfProvider** was added to extend the same
 | [EasyReasy.ByteShelfProvider](EasyReasy.ByteShelfProvider/README.md) | [![NuGet](https://img.shields.io/badge/nuget-EasyReasy.ByteShelfProvider-blue.svg)](https://www.nuget.org/packages/EasyReasy.ByteShelfProvider) | ByteShelf integration for remote file access |
 | [EasyReasy.Auth](EasyReasy.Auth/README.md) | [![NuGet](https://img.shields.io/badge/nuget-EasyReasy.Auth-blue.svg)](https://www.nuget.org/packages/EasyReasy.Auth) | JWT authentication and claims handling |
 | [EasyReasy.Auth.Client](EasyReasy.Auth.Client/README.md) | [![NuGet](https://img.shields.io/badge/nuget-EasyReasy.Auth.Client-blue.svg)](https://www.nuget.org/packages/EasyReasy.Auth.Client) | Lightweight client library for EasyReasy.Auth servers |
+| [EasyReasy.Auth.Google](EasyReasy.Auth.Google/README.md) | [![NuGet](https://img.shields.io/badge/nuget-EasyReasy.Auth.Google-blue.svg)](https://www.nuget.org/packages/EasyReasy.Auth.Google) | Google Sign-In integration for EasyReasy.Auth |
 | [EasyReasy.VectorStorage](EasyReasy.VectorStorage/README.md) | [![NuGet](https://img.shields.io/badge/nuget-EasyReasy.VectorStorage-blue.svg)](https://www.nuget.org/packages/EasyReasy.VectorStorage) | High-performance vector similarity search with cosine similarity |
 
 


### PR DESCRIPTION
## Why?

Adds "Sign in with Google" as another authentication method in the EasyReasy ecosystem, so consumers can verify Google ID tokens and issue the same JWTs (and optional refresh tokens) as the existing auth methods. The branch had diverged far from `master`, so it also rebases onto and modernizes against the current `EasyReasy.Auth` (net10, refresh tokens, audit logging).

## What?

A new `EasyReasy.Auth.Google` library (plus its test project), and a small additive hook in the core `EasyReasy.Auth` so external sign-ins flow through the existing audit pipeline.

**`EasyReasy.Auth.Google`**
- Google ID token validation via `Google.Apis.Auth`, with a configurable client ID, an optional case-insensitive hosted-domain allowlist, and email-verification enforcement (on by default).
- `IGoogleAuthHandler` — the consumer-implemented integration point; it receives the verified `GoogleUserInfo` plus the JWT and optional refresh-token services and returns an `AuthResponse`.
- `POST /api/auth/google` via `AddGoogleAuthEndpoint()` — anonymous, sets `Cache-Control: no-store`, fails fast at startup when its required services aren't registered, and invokes the audit hook on every attempt.
- `AddEasyReasyGoogleAuth(...)` for DI registration. Targets net10, with unit tests plus an in-process endpoint integration test.

**`EasyReasy.Auth` (5.2.0 → 5.3.0)**
- New generic external-identity-provider audit hook: `IAuthAuditLogger.OnExternalAuthAsync(httpContext, ExternalAuthResult)`, with `ExternalAuthResult` / `ExternalAuthFailureReason`. Google sign-ins report to the same audit sink as the built-in login/API-key/refresh endpoints. Additive and non-breaking (default interface method).

## Challenges

- **Rebase scope.** The branch predated ~30 commits of `EasyReasy.Auth` evolution (1.4 → 5.2, net8 → net10, refresh tokens, options pattern, audit logging). The library was modernized to integrate with the current API rather than the one it was written against.
- **Audit-logging design.** A Google-specific hook on the core `IAuthAuditLogger` would have pulled provider-specific types into the provider-agnostic core and inverted the dependency direction. A single generic external-provider hook keeps the core clean and lets future providers (Apple, Microsoft) reuse it.
- **Secure defaults, made testable.** Unverified emails are rejected by default and hosted-domain matching is case-insensitive (per Google's guidance). The post-validation policy was extracted into its own unit so these security branches have direct test coverage.

## Left for future work

- The network-bound part of token validation (`GoogleJsonWebSignature.ValidateAsync` against Google's public keys) is still not unit-tested — only the post-validation policy is. Covering it would need an integration test or a fake signing setup.