### PR TITLE
Add logout endpoint and bulk refresh token invalidation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+name: Publish NuGet
+
+on:
+  push:
+    tags:
+      - '*-v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Parse tag
+      id: tag
+      run: |
+        TAG="${GITHUB_REF_NAME}"
+        PACKAGE="${TAG%-v*}"
+        VERSION="${TAG##*-v}"
+        echo "PACKAGE=${PACKAGE}" >> $GITHUB_OUTPUT
+        echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+        echo "Publishing package '${PACKAGE}' version ${VERSION}"
+
+    - name: Resolve project
+      id: project
+      run: |
+        PACKAGE="${{ steps.tag.outputs.PACKAGE }}"
+        # Map tag prefix to project name + matching test project.
+        case "$PACKAGE" in
+          core)          PROJECT="EasyReasy";                     TEST_PROJECT="EasyReasy.Tests" ;;
+          auth)          PROJECT="EasyReasy.Auth";                TEST_PROJECT="EasyReasy.Auth.Tests" ;;
+          auth-client)   PROJECT="EasyReasy.Auth.Client";         TEST_PROJECT="EasyReasy.Auth.Client.Tests" ;;
+          byteshelf)     PROJECT="EasyReasy.ByteShelfProvider";   TEST_PROJECT="EasyReasy.ByteShelfProvider.Tests" ;;
+          env)           PROJECT="EasyReasy.EnvironmentVariables"; TEST_PROJECT="EasyReasy.EnvironmentVariables.Tests" ;;
+          vectorstorage) PROJECT="EasyReasy.VectorStorage";       TEST_PROJECT="EasyReasy.VectorStorage.Tests" ;;
+          *)             echo "Unknown package: $PACKAGE" && exit 1 ;;
+        esac
+        echo "PROJECT=${PROJECT}" >> $GITHUB_OUTPUT
+        echo "TEST_PROJECT=${TEST_PROJECT}" >> $GITHUB_OUTPUT
+        echo "Project: ${PROJECT}"
+        echo "Test project: ${TEST_PROJECT}"
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore --configuration Release -p:Version=${{ steps.tag.outputs.VERSION }}
+
+    # Only run the test project matching the package being published, and skip
+    # integration-flavoured tests that require external services (real ByteShelf
+    # backend, remote auth server) or are placeholders not meant for CI.
+    - name: Test
+      run: dotnet test ${{ steps.project.outputs.TEST_PROJECT }} --no-build --configuration Release --filter "FullyQualifiedName!~IntegrationTests"
+
+    - name: Pack
+      run: dotnet pack ${{ steps.project.outputs.PROJECT }} --no-build --configuration Release -p:Version=${{ steps.tag.outputs.VERSION }} --output ./nupkgs
+
+    - name: Publish to NuGet
+      run: dotnet nuget push ./nupkgs/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,13 @@ jobs:
     - name: Build
       run: dotnet build --no-restore --configuration Release -p:Version=${{ steps.tag.outputs.VERSION }}
 
-    # Only run the test project matching the package being published, and skip
-    # integration-flavoured tests that require external services (real ByteShelf
-    # backend, remote auth server) or are placeholders not meant for CI.
+    # Only run the test project matching the package being published, and skip:
+    # - IntegrationTests: require external services (real ByteShelf backend,
+    #   remote auth server) or are placeholders not meant for CI.
+    # - PerformanceTest: memory/timing assertions that are unreliable on
+    #   shared CI runners.
     - name: Test
-      run: dotnet test ${{ steps.project.outputs.TEST_PROJECT }} --no-build --configuration Release --filter "FullyQualifiedName!~IntegrationTests"
+      run: dotnet test ${{ steps.project.outputs.TEST_PROJECT }} --no-build --configuration Release --filter "FullyQualifiedName!~IntegrationTests&FullyQualifiedName!~PerformanceTest"
 
     - name: Pack
       run: dotnet pack ${{ steps.project.outputs.PROJECT }} --no-build --configuration Release -p:Version=${{ steps.tag.outputs.VERSION }} --output ./nupkgs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: ["master"]
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore --configuration Release
+
+    # Run every test project but skip integration-flavoured tests that require
+    # external services (real ByteShelf backend, remote auth server) or are
+    # placeholders not meant for CI.
+    - name: Test
+      run: dotnet test --no-build --configuration Release --filter "FullyQualifiedName!~IntegrationTests"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,10 @@ jobs:
     - name: Build
       run: dotnet build --no-restore --configuration Release
 
-    # Run every test project but skip integration-flavoured tests that require
-    # external services (real ByteShelf backend, remote auth server) or are
-    # placeholders not meant for CI.
+    # Run every test project but skip:
+    # - IntegrationTests: require external services (real ByteShelf backend,
+    #   remote auth server) or are placeholders not meant for CI.
+    # - PerformanceTest: memory/timing assertions that are unreliable on
+    #   shared CI runners.
     - name: Test
-      run: dotnet test --no-build --configuration Release --filter "FullyQualifiedName!~IntegrationTests"
+      run: dotnet test --no-build --configuration Release --filter "FullyQualifiedName!~IntegrationTests&FullyQualifiedName!~PerformanceTest"

--- a/EasyReasy.Auth.Client.Tests/AuthorizedHttpClientTests.cs
+++ b/EasyReasy.Auth.Client.Tests/AuthorizedHttpClientTests.cs
@@ -504,5 +504,190 @@ namespace EasyReasy.Auth.Client.Tests
         }
 
         #endregion
+
+        #region LogoutAsync
+
+        [TestMethod]
+        public async Task LogoutAsync_WithRefreshToken_PostsToLogoutEndpoint()
+        {
+            // Arrange
+            FakeHttpHandler handler = new FakeHttpHandler();
+            handler.EnqueueResponse(new HttpResponseMessage(HttpStatusCode.NoContent));
+
+            HttpClient httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/") };
+            AuthResponse authResponse = CreateValidAuthResponse(refreshToken: "the-refresh-token");
+
+            using AuthorizedHttpClient client = new AuthorizedHttpClient(httpClient, authResponse);
+
+            // Act
+            await client.LogoutAsync();
+
+            // Assert
+            Assert.AreEqual(1, handler.SentRequests.Count);
+            Assert.AreEqual("https://example.com/api/auth/logout", handler.SentRequests[0].RequestUri?.ToString());
+            string body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+            Assert.IsTrue(body.Contains("the-refresh-token"));
+            Assert.IsTrue(body.Contains("refreshToken"));
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_OnSuccess_ClearsLocalAuthState()
+        {
+            // Arrange
+            FakeHttpHandler handler = new FakeHttpHandler();
+            handler.EnqueueResponse(new HttpResponseMessage(HttpStatusCode.NoContent));
+
+            HttpClient httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/") };
+            AuthResponse authResponse = CreateValidAuthResponse(token: "live-token", refreshToken: "live-refresh");
+
+            using AuthorizedHttpClient client = new AuthorizedHttpClient(httpClient, authResponse);
+
+            // Sanity check — header is set before logout
+            Assert.AreEqual("live-token", httpClient.DefaultRequestHeaders.Authorization?.Parameter);
+
+            // Act
+            await client.LogoutAsync();
+
+            // Assert
+            Assert.IsNull(httpClient.DefaultRequestHeaders.Authorization);
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_WithNoRefreshToken_DoesNotMakeHttpCall()
+        {
+            // Arrange
+            FakeHttpHandler handler = new FakeHttpHandler();
+
+            HttpClient httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/") };
+            AuthResponse authResponse = CreateValidAuthResponse(refreshToken: null);
+
+            using AuthorizedHttpClient client = new AuthorizedHttpClient(httpClient, authResponse);
+
+            // Act
+            await client.LogoutAsync();
+
+            // Assert — no HTTP calls, but local state still cleared
+            Assert.AreEqual(0, handler.SentRequests.Count);
+            Assert.IsNull(httpClient.DefaultRequestHeaders.Authorization);
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_ServerReturnsError_DoesNotThrowAndClearsState()
+        {
+            // Arrange
+            FakeHttpHandler handler = new FakeHttpHandler();
+            handler.EnqueueResponse(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+            HttpClient httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/") };
+            AuthResponse authResponse = CreateValidAuthResponse(refreshToken: "some-refresh");
+
+            using AuthorizedHttpClient client = new AuthorizedHttpClient(httpClient, authResponse);
+
+            // Act
+            await client.LogoutAsync();
+
+            // Assert
+            Assert.IsNull(httpClient.DefaultRequestHeaders.Authorization);
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_AfterLogout_ApiKeyClientTriggersReauth()
+        {
+            // Arrange
+            FakeHttpHandler handler = new FakeHttpHandler();
+
+            // 1. Initial auth
+            handler.EnqueueJsonResponse(CreateAuthResponseJson(token: "first-token", refreshToken: "first-refresh"));
+            // 2. Some API call
+            handler.EnqueueJsonResponse("{\"data\":\"hello\"}");
+            // 3. Logout (204)
+            handler.EnqueueResponse(new HttpResponseMessage(HttpStatusCode.NoContent));
+            // 4. Re-auth after logout
+            handler.EnqueueJsonResponse(CreateAuthResponseJson(token: "second-token", refreshToken: "second-refresh"));
+            // 5. Next API call
+            handler.EnqueueJsonResponse("{\"data\":\"world\"}");
+
+            HttpClient httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/") };
+
+            using AuthorizedHttpClient client = new AuthorizedHttpClient(httpClient, apiKey: "my-api-key");
+
+            // Act
+            await client.GetAsync("api/test");
+            await client.LogoutAsync();
+            await client.GetAsync("api/test");
+
+            // Assert — expect 5 requests total: auth, get, logout, auth, get
+            Assert.AreEqual(5, handler.SentRequests.Count);
+            Assert.IsTrue(handler.SentRequests[2].RequestUri?.ToString().Contains("api/auth/logout"));
+            Assert.IsTrue(handler.SentRequests[3].RequestUri?.ToString().Contains("api/auth/apikey"));
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_CancelledMidFlight_ClearsLocalStateAndPropagatesCancellation()
+        {
+            // Arrange — handler signals when it enters SendAsync, and blocks there until cancelled.
+            TaskCompletionSource handlerEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            BlockingHttpHandler handler = new BlockingHttpHandler(handlerEntered);
+            HttpClient httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/") };
+            AuthResponse authResponse = CreateValidAuthResponse(token: "live-token", refreshToken: "live-refresh");
+
+            using AuthorizedHttpClient client = new AuthorizedHttpClient(httpClient, authResponse);
+
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            // Act — start logout, wait until the handler has been entered (lock acquired, HTTP in flight),
+            // then cancel. This guarantees cancellation fires after the logout sequence has begun.
+            Task logoutTask = client.LogoutAsync(cts.Token);
+            await handlerEntered.Task;
+            cts.Cancel();
+
+            // Assert — cancellation should propagate. HttpClient.PostAsync throws
+            // TaskCanceledException specifically (a subtype of OperationCanceledException),
+            // and MSTest's ThrowsException does exact-type matching.
+            await Assert.ThrowsExceptionAsync<TaskCanceledException>(() => logoutTask);
+
+            // And local state must be cleared regardless
+            Assert.IsNull(httpClient.DefaultRequestHeaders.Authorization);
+        }
+
+        private sealed class BlockingHttpHandler : HttpMessageHandler
+        {
+            private readonly TaskCompletionSource _entered;
+
+            public BlockingHttpHandler(TaskCompletionSource entered)
+            {
+                _entered = entered;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                _entered.TrySetResult();
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+                throw new InvalidOperationException("Unreachable");
+            }
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_WithCustomLogoutEndpoint_UsesCustomPath()
+        {
+            // Arrange
+            FakeHttpHandler handler = new FakeHttpHandler();
+            handler.EnqueueResponse(new HttpResponseMessage(HttpStatusCode.NoContent));
+
+            HttpClient httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/") };
+            AuthResponse authResponse = CreateValidAuthResponse(refreshToken: "some-refresh");
+
+            using AuthorizedHttpClient client = new AuthorizedHttpClient(
+                httpClient, authResponse, logoutEndpoint: "custom/logout");
+
+            // Act
+            await client.LogoutAsync();
+
+            // Assert
+            Assert.AreEqual("https://example.com/custom/logout", handler.SentRequests[0].RequestUri?.ToString());
+        }
+
+        #endregion
     }
 }

--- a/EasyReasy.Auth.Client.Tests/RemoteIntegrationTests.cs
+++ b/EasyReasy.Auth.Client.Tests/RemoteIntegrationTests.cs
@@ -4,6 +4,7 @@
     public class RemoteIntegrationTests
     {
         [TestMethod]
+        [Ignore("Local-only smoke test: fill in a real base address and API key, then remove [Ignore] to run against a live server.")]
         public async Task CreateAuthenticatedClient()
         {
             // Arrange

--- a/EasyReasy.Auth.Client/AuthorizedHttpClient.cs
+++ b/EasyReasy.Auth.Client/AuthorizedHttpClient.cs
@@ -35,6 +35,7 @@ namespace EasyReasy.Auth.Client
         private readonly AuthType _authType;
         private readonly string _authEndpoint;
         private readonly string _refreshEndpoint;
+        private readonly string _logoutEndpoint;
         private readonly Action<AuthResponse>? _onAuthResponseChanged;
         private readonly SemaphoreSlim _authLock = new SemaphoreSlim(1, 1);
         private string? _refreshToken;
@@ -49,12 +50,14 @@ namespace EasyReasy.Auth.Client
         /// <param name="apiKey">The API key for authentication.</param>
         /// <param name="authEndpoint">The authentication endpoint path. If not specified, defaults to "/api/auth/apikey".</param>
         /// <param name="refreshEndpoint">The refresh token endpoint path. If not specified, defaults to "/api/auth/refresh".</param>
+        /// <param name="logoutEndpoint">The logout endpoint path. If not specified, defaults to "/api/auth/logout".</param>
         /// <param name="onAuthResponseChanged">An optional callback invoked whenever the auth state changes (initial auth, token refresh, or re-auth).</param>
         public AuthorizedHttpClient(
             HttpClient httpClient,
             string apiKey,
             string? authEndpoint = null,
             string? refreshEndpoint = null,
+            string? logoutEndpoint = null,
             Action<AuthResponse>? onAuthResponseChanged = null)
         {
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
@@ -65,6 +68,7 @@ namespace EasyReasy.Auth.Client
             _apiKey = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
             _authEndpoint = authEndpoint ?? "api/auth/apikey";
             _refreshEndpoint = refreshEndpoint ?? "api/auth/refresh";
+            _logoutEndpoint = logoutEndpoint ?? "api/auth/logout";
             _authType = AuthType.ApiKey;
             _onAuthResponseChanged = onAuthResponseChanged;
         }
@@ -77,6 +81,7 @@ namespace EasyReasy.Auth.Client
         /// <param name="password">The password for authentication.</param>
         /// <param name="authEndpoint">The authentication endpoint path. If not specified, defaults to "/api/auth/login".</param>
         /// <param name="refreshEndpoint">The refresh token endpoint path. If not specified, defaults to "/api/auth/refresh".</param>
+        /// <param name="logoutEndpoint">The logout endpoint path. If not specified, defaults to "/api/auth/logout".</param>
         /// <param name="onAuthResponseChanged">An optional callback invoked whenever the auth state changes (initial auth, token refresh, or re-auth).</param>
         public AuthorizedHttpClient(
             HttpClient httpClient,
@@ -84,6 +89,7 @@ namespace EasyReasy.Auth.Client
             string password,
             string? authEndpoint = null,
             string? refreshEndpoint = null,
+            string? logoutEndpoint = null,
             Action<AuthResponse>? onAuthResponseChanged = null)
         {
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
@@ -91,6 +97,7 @@ namespace EasyReasy.Auth.Client
             _password = password ?? throw new ArgumentNullException(nameof(password));
             _authEndpoint = authEndpoint ?? "api/auth/login";
             _refreshEndpoint = refreshEndpoint ?? "api/auth/refresh";
+            _logoutEndpoint = logoutEndpoint ?? "api/auth/logout";
             _authType = AuthType.UsernamePassword;
             _onAuthResponseChanged = onAuthResponseChanged;
         }
@@ -102,11 +109,13 @@ namespace EasyReasy.Auth.Client
         /// <param name="httpClient">The HTTP client to use for requests.</param>
         /// <param name="authResponse">The authentication response containing the token, expiration, and optional refresh token.</param>
         /// <param name="refreshEndpoint">The refresh token endpoint path. If not specified, defaults to "/api/auth/refresh".</param>
+        /// <param name="logoutEndpoint">The logout endpoint path. If not specified, defaults to "/api/auth/logout".</param>
         /// <param name="onAuthResponseChanged">An optional callback invoked whenever the auth state changes (initial auth, token refresh, or re-auth).</param>
         public AuthorizedHttpClient(
             HttpClient httpClient,
             AuthResponse authResponse,
             string? refreshEndpoint = null,
+            string? logoutEndpoint = null,
             Action<AuthResponse>? onAuthResponseChanged = null)
         {
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
@@ -117,6 +126,7 @@ namespace EasyReasy.Auth.Client
             ArgumentNullException.ThrowIfNull(authResponse);
             _authEndpoint = string.Empty;
             _refreshEndpoint = refreshEndpoint ?? "api/auth/refresh";
+            _logoutEndpoint = logoutEndpoint ?? "api/auth/logout";
             _authType = AuthType.PreAuthorized;
             _onAuthResponseChanged = onAuthResponseChanged;
 
@@ -206,11 +216,69 @@ namespace EasyReasy.Auth.Client
             await _authLock.WaitAsync(cancellationToken);
             try
             {
-                _isAuthorized = false;
-                _tokenExpiresAt = null;
-                _refreshToken = null;
-                _httpClient.DefaultRequestHeaders.Authorization = null;
+                ClearLocalAuthState();
                 await AuthorizeAsync(cancellationToken);
+            }
+            finally
+            {
+                _authLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Resets every field and header that represents "the client is authenticated"
+        /// back to the unauthenticated defaults. Must only be called while holding
+        /// <see cref="_authLock"/>.
+        /// </summary>
+        private void ClearLocalAuthState()
+        {
+            _isAuthorized = false;
+            _tokenExpiresAt = null;
+            _refreshToken = null;
+            _httpClient.DefaultRequestHeaders.Authorization = null;
+        }
+
+        /// <summary>
+        /// Logs out by posting the current refresh token to the logout endpoint, then clears
+        /// all local authorization state. The server call is best-effort — HTTP failures
+        /// (non-success status codes, transient network errors) do not prevent the local state
+        /// from being cleared.
+        /// </summary>
+        /// <remarks>
+        /// Cancellation semantics:
+        /// <list type="bullet">
+        /// <item><description>If cancellation fires <em>after</em> the logout sequence begins (i.e. during the HTTP call), local state is cleared before the <see cref="OperationCanceledException"/> propagates.</description></item>
+        /// <item><description>If cancellation fires <em>before</em> the logout sequence begins (e.g. while awaiting the internal synchronization lock during a concurrent operation), the call is aborted with no side effects — client state is unchanged.</description></item>
+        /// </list>
+        /// </remarks>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        public async Task LogoutAsync(CancellationToken cancellationToken = default)
+        {
+            await _authLock.WaitAsync(cancellationToken);
+            try
+            {
+                try
+                {
+                    if (_refreshToken != null)
+                    {
+                        LogoutRequest logoutRequest = new LogoutRequest(_refreshToken);
+                        StringContent content = new StringContent(logoutRequest.ToJson(), System.Text.Encoding.UTF8, "application/json");
+                        await _httpClient.PostAsync(_logoutEndpoint, content, cancellationToken);
+                    }
+                }
+                catch (HttpRequestException)
+                {
+                    // Logout is best-effort: a transient network error or non-success response
+                    // must not block the caller from ending up unauthenticated locally. The
+                    // server-side family invalidation will be retried implicitly the next time
+                    // the (now-discarded) refresh token is replayed.
+                }
+                finally
+                {
+                    // Always clear state — even if the server call was cancelled or failed —
+                    // so that the client ends up unauthenticated once the logout sequence begins.
+                    ClearLocalAuthState();
+                }
             }
             finally
             {

--- a/EasyReasy.Auth.Client/EasyReasy.Auth.Client.csproj
+++ b/EasyReasy.Auth.Client/EasyReasy.Auth.Client.csproj
@@ -18,7 +18,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <VersionPrefix>1.5.0</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EasyReasy.Auth.Client/LogoutRequest.cs
+++ b/EasyReasy.Auth.Client/LogoutRequest.cs
@@ -5,7 +5,7 @@ namespace EasyReasy.Auth.Client
     /// <summary>
     /// Request model for logging out by revoking a refresh token family.
     /// </summary>
-    public class LogoutRequest
+    public sealed class LogoutRequest
     {
         /// <summary>
         /// Gets the refresh token whose family should be invalidated.

--- a/EasyReasy.Auth.Client/LogoutRequest.cs
+++ b/EasyReasy.Auth.Client/LogoutRequest.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+
+namespace EasyReasy.Auth.Client
+{
+    /// <summary>
+    /// Request model for logging out by revoking a refresh token family.
+    /// </summary>
+    public class LogoutRequest
+    {
+        /// <summary>
+        /// Gets the refresh token whose family should be invalidated.
+        /// </summary>
+        public string RefreshToken { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LogoutRequest"/> class.
+        /// </summary>
+        /// <param name="refreshToken">The refresh token to log out.</param>
+        public LogoutRequest(string refreshToken)
+        {
+            RefreshToken = refreshToken;
+        }
+
+        /// <summary>
+        /// Serializes this <see cref="LogoutRequest"/> instance to a JSON string.
+        /// </summary>
+        /// <returns>A JSON string representation of this <see cref="LogoutRequest"/> instance.</returns>
+        public string ToJson()
+        {
+            return JsonSerializer.Serialize(this, JsonSerializerSettings.CurrentOptions);
+        }
+
+        /// <summary>
+        /// Returns a string representation of this <see cref="LogoutRequest"/> instance
+        /// with the refresh token redacted to prevent accidental secret leakage in logs.
+        /// </summary>
+        /// <returns>A string representation with the refresh token replaced by "[REDACTED]".</returns>
+        public override string ToString()
+        {
+            return $"{{\"refreshToken\":\"[REDACTED]\"}}";
+        }
+
+        /// <summary>
+        /// Creates a <see cref="LogoutRequest"/> instance from a JSON string.
+        /// </summary>
+        /// <param name="json">The JSON string to deserialize.</param>
+        /// <returns>A <see cref="LogoutRequest"/> instance.</returns>
+        /// <exception cref="ArgumentException">Thrown when the JSON cannot be deserialized into a <see cref="LogoutRequest"/>.</exception>
+        public static LogoutRequest FromJson(string json)
+        {
+            try
+            {
+                LogoutRequest? result = JsonSerializer.Deserialize<LogoutRequest>(json, JsonSerializerSettings.CurrentOptions);
+
+                if (result == null)
+                {
+                    throw new ArgumentException($"Failed to deserialize {nameof(LogoutRequest)} from the provided JSON.");
+                }
+
+                return result;
+            }
+            catch (JsonException)
+            {
+                throw new ArgumentException($"Failed to deserialize {nameof(LogoutRequest)} from the provided JSON.");
+            }
+        }
+    }
+}

--- a/EasyReasy.Auth.Client/README.md
+++ b/EasyReasy.Auth.Client/README.md
@@ -212,20 +212,18 @@ The client automatically handles token expiration:
 `LogoutAsync()` posts the current refresh token to the server's logout endpoint (default `/api/auth/logout`) and then clears all local auth state. The server call is best-effort — HTTP failures do not prevent local state from being cleared, so the client always ends up in an unauthenticated state after the call.
 
 ```csharp
-using (HttpClient httpClient = AuthorizedHttpClient.CreateHttpClient("https://api.example.com/"))
-{
-    AuthorizedHttpClient client = new AuthorizedHttpClient(
-        httpClient, username: "user", password: "pass");
+using HttpClient httpClient = AuthorizedHttpClient.CreateHttpClient("https://api.example.com/");
+using AuthorizedHttpClient client = new AuthorizedHttpClient(
+    httpClient, username: "user", password: "pass");
 
-    await client.GetAsync("api/data");
+await client.GetAsync("api/data");
 
-    // Later — revoke the refresh token family and clear local state.
-    await client.LogoutAsync();
+// Later — revoke the refresh token family and clear local state.
+await client.LogoutAsync();
 
-    // Subsequent requests will trigger a fresh authentication flow
-    // (only possible when the client has credentials — API key or username/password.
-    // A pre-authorized client cannot re-authenticate after logout.)
-}
+// Subsequent requests will trigger a fresh authentication flow
+// (only possible when the client has credentials — API key or username/password.
+// A pre-authorized client cannot re-authenticate after logout.)
 ```
 
 You can override the logout endpoint path via the `logoutEndpoint` constructor parameter if your server mounts it elsewhere.

--- a/EasyReasy.Auth.Client/README.md
+++ b/EasyReasy.Auth.Client/README.md
@@ -207,6 +207,29 @@ The client automatically handles token expiration:
 2. Automatically re-authenticates before making requests
 3. Retries failed requests once with a fresh token
 
+### Logging Out
+
+`LogoutAsync()` posts the current refresh token to the server's logout endpoint (default `/api/auth/logout`) and then clears all local auth state. The server call is best-effort — HTTP failures do not prevent local state from being cleared, so the client always ends up in an unauthenticated state after the call.
+
+```csharp
+using (HttpClient httpClient = AuthorizedHttpClient.CreateHttpClient("https://api.example.com/"))
+{
+    AuthorizedHttpClient client = new AuthorizedHttpClient(
+        httpClient, username: "user", password: "pass");
+
+    await client.GetAsync("api/data");
+
+    // Later — revoke the refresh token family and clear local state.
+    await client.LogoutAsync();
+
+    // Subsequent requests will trigger a fresh authentication flow
+    // (only possible when the client has credentials — API key or username/password.
+    // A pre-authorized client cannot re-authenticate after logout.)
+}
+```
+
+You can override the logout endpoint path via the `logoutEndpoint` constructor parameter if your server mounts it elsewhere.
+
 ## Best Practices
 
 ### 1. HttpClient Lifecycle Management

--- a/EasyReasy.Auth.Tests/AddAuthEndpointsStartupGuardTests.cs
+++ b/EasyReasy.Auth.Tests/AddAuthEndpointsStartupGuardTests.cs
@@ -1,0 +1,102 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace EasyReasy.Auth.Tests
+{
+    /// <summary>
+    /// Verifies the fail-fast startup guards in <see cref="AuthApplicationBuilderExtensions.AddAuthEndpoints"/>.
+    /// Ensures missing DI registrations throw a clear <see cref="InvalidOperationException"/>, and that the
+    /// guards correctly gate on the endpoint enable-flags (so a consumer enabling only one endpoint family
+    /// doesn't have to register services for the other).
+    /// </summary>
+    [TestClass]
+    public class AddAuthEndpointsStartupGuardTests
+    {
+        private const string Secret = "super_secret_key_12345_12345_12345";
+
+        [TestMethod]
+        public void AddAuthEndpoints_WithLogoutEnabledAndNoRefreshTokenService_ShouldThrow()
+        {
+            WebApplicationBuilder builder = CreateBuilder();
+            builder.Services.AddSingleton<IAuthRequestValidationService, NoopValidationService>();
+            WebApplication app = builder.Build();
+
+            InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(
+                () => app.AddAuthEndpoints(allowRefresh: false, allowLogout: true));
+
+            StringAssert.Contains(exception.Message, nameof(IRefreshTokenService));
+        }
+
+        [TestMethod]
+        public void AddAuthEndpoints_WithRefreshEnabledAndNoRefreshTokenService_ShouldThrow()
+        {
+            WebApplicationBuilder builder = CreateBuilder();
+            builder.Services.AddSingleton<IAuthRequestValidationService, NoopValidationService>();
+            WebApplication app = builder.Build();
+
+            InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(
+                () => app.AddAuthEndpoints(allowRefresh: true, allowLogout: false));
+
+            StringAssert.Contains(exception.Message, nameof(IRefreshTokenService));
+        }
+
+        [TestMethod]
+        public void AddAuthEndpoints_WithApiKeysEnabledAndNoValidationService_ShouldThrow()
+        {
+            WebApplicationBuilder builder = CreateBuilder();
+            WebApplication app = builder.Build();
+
+            InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(
+                () => app.AddAuthEndpoints(allowApiKeys: true, allowUsernamePassword: false, allowLogout: false));
+
+            StringAssert.Contains(exception.Message, nameof(IAuthRequestValidationService));
+        }
+
+        [TestMethod]
+        public void AddAuthEndpoints_WithAllApiKeyLoginLogoutDisabled_ShouldNotRequireValidationService()
+        {
+            // Only refresh enabled; validation service is not needed and should not be checked.
+            WebApplicationBuilder builder = CreateBuilder();
+            builder.Services.AddRefreshTokenService<FakeRefreshTokenStore>();
+            WebApplication app = builder.Build();
+
+            // Should not throw despite no IAuthRequestValidationService registered.
+            app.AddAuthEndpoints(allowApiKeys: false, allowUsernamePassword: false, allowRefresh: true, allowLogout: false);
+        }
+
+        [TestMethod]
+        public void AddAuthEndpoints_WithOnlyLogoutEnabledAndRefreshTokenServiceRegistered_ShouldNotRequireValidationService()
+        {
+            WebApplicationBuilder builder = CreateBuilder();
+            builder.Services.AddRefreshTokenService<FakeRefreshTokenStore>();
+            WebApplication app = builder.Build();
+
+            app.AddAuthEndpoints(allowApiKeys: false, allowUsernamePassword: false, allowRefresh: false, allowLogout: true);
+        }
+
+        private static WebApplicationBuilder CreateBuilder()
+        {
+            WebApplicationBuilder builder = WebApplication.CreateBuilder();
+            builder.WebHost.UseTestServer();
+            builder.Logging.ClearProviders();
+            builder.Services.AddEasyReasyAuth(Secret);
+            return builder;
+        }
+
+        private sealed class NoopValidationService : IAuthRequestValidationService
+        {
+            public Task<ApiKeyAuthResult> ValidateApiKeyRequestAsync(ApiKeyAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
+            {
+                return Task.FromResult(ApiKeyAuthResult.Failed(ApiKeyAuthFailureReason.UnknownKey));
+            }
+
+            public Task<LoginResult> ValidateLoginRequestAsync(LoginAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
+            {
+                return Task.FromResult(LoginResult.Failed(LoginFailureReason.InvalidCredentials));
+            }
+        }
+    }
+}

--- a/EasyReasy.Auth.Tests/ApiKeyAuthResultTests.cs
+++ b/EasyReasy.Auth.Tests/ApiKeyAuthResultTests.cs
@@ -1,0 +1,55 @@
+namespace EasyReasy.Auth.Tests
+{
+    [TestClass]
+    public class ApiKeyAuthResultTests
+    {
+        [TestMethod]
+        public void Succeeded_ShouldCreateSuccessfulResult()
+        {
+            AuthResponse authResponse = new AuthResponse("jwt-token", "2025-01-01T00:00:00Z");
+
+            ApiKeyAuthResult result = ApiKeyAuthResult.Succeeded(authResponse, "client-42");
+
+            Assert.IsTrue(result.Success);
+            Assert.AreSame(authResponse, result.AuthResponse);
+            Assert.AreEqual("client-42", result.AttemptedClientId);
+            Assert.IsNull(result.FailureReason);
+        }
+
+        [TestMethod]
+        public void Failed_ShouldCreateFailedResult()
+        {
+            ApiKeyAuthResult result = ApiKeyAuthResult.Failed(ApiKeyAuthFailureReason.UnknownKey);
+
+            Assert.IsFalse(result.Success);
+            Assert.IsNull(result.AuthResponse);
+            Assert.AreEqual(ApiKeyAuthFailureReason.UnknownKey, result.FailureReason);
+        }
+
+        [TestMethod]
+        public void Failed_WithoutAttemptedClientId_ShouldDefaultToNull()
+        {
+            ApiKeyAuthResult result = ApiKeyAuthResult.Failed(ApiKeyAuthFailureReason.UnknownKey);
+
+            Assert.IsNull(result.AttemptedClientId);
+        }
+
+        [TestMethod]
+        public void Failed_WithAttemptedClientId_ShouldPopulateIt()
+        {
+            ApiKeyAuthResult result = ApiKeyAuthResult.Failed(ApiKeyAuthFailureReason.KeyRevoked, attemptedClientId: "client-x");
+
+            Assert.AreEqual("client-x", result.AttemptedClientId);
+            Assert.AreEqual(ApiKeyAuthFailureReason.KeyRevoked, result.FailureReason);
+        }
+
+        [TestMethod]
+        public void Failed_WithEachReason_ShouldSetReasonCorrectly()
+        {
+            Assert.AreEqual(ApiKeyAuthFailureReason.UnknownKey, ApiKeyAuthResult.Failed(ApiKeyAuthFailureReason.UnknownKey).FailureReason);
+            Assert.AreEqual(ApiKeyAuthFailureReason.KeyRevoked, ApiKeyAuthResult.Failed(ApiKeyAuthFailureReason.KeyRevoked).FailureReason);
+            Assert.AreEqual(ApiKeyAuthFailureReason.KeyExpired, ApiKeyAuthResult.Failed(ApiKeyAuthFailureReason.KeyExpired).FailureReason);
+            Assert.AreEqual(ApiKeyAuthFailureReason.Other, ApiKeyAuthResult.Failed(ApiKeyAuthFailureReason.Other).FailureReason);
+        }
+    }
+}

--- a/EasyReasy.Auth.Tests/AuthAuditLoggerDiTests.cs
+++ b/EasyReasy.Auth.Tests/AuthAuditLoggerDiTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EasyReasy.Auth.Tests
+{
+    /// <summary>
+    /// DI-level tests proving that a registered <see cref="IAuthAuditLogger"/> is resolved and invoked
+    /// by the refresh token service wiring in <c>AddRefreshTokenService</c>.
+    /// Endpoint-level integration tests are intentionally not included here because the endpoint wiring
+    /// simply forwards to the service layer — these tests verify the wiring path that is unique to this library.
+    /// </summary>
+    [TestClass]
+    public class AuthAuditLoggerDiTests
+    {
+        [TestMethod]
+        public async Task RegisteredAuditLogger_ShouldBeInvokedByInvalidateAllSessionsAsync()
+        {
+            ServiceCollection services = new ServiceCollection();
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            services.AddSingleton<IAuthAuditLogger>(auditLogger);
+            services.AddRefreshTokenService<FakeRefreshTokenStore>();
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+            using IServiceScope scope = provider.CreateScope();
+
+            IRefreshTokenService refreshService = scope.ServiceProvider.GetRequiredService<IRefreshTokenService>();
+            await refreshService.CreateRefreshTokenAsync("user-42", "user", null, null);
+
+            SessionRevocationResult result = await refreshService.InvalidateAllSessionsAsync("user-42");
+
+            Assert.AreEqual(1, auditLogger.SessionsInvalidatedCalls.Count);
+            Assert.AreSame(result, auditLogger.SessionsInvalidatedCalls[0]);
+            Assert.AreEqual("user-42", result.Subject);
+            Assert.AreEqual(1, result.InvalidatedFamilyCount);
+        }
+
+        [TestMethod]
+        public async Task NoAuditLoggerRegistered_ShouldNotThrow()
+        {
+            ServiceCollection services = new ServiceCollection();
+            services.AddRefreshTokenService<FakeRefreshTokenStore>();
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+            using IServiceScope scope = provider.CreateScope();
+
+            IRefreshTokenService refreshService = scope.ServiceProvider.GetRequiredService<IRefreshTokenService>();
+            await refreshService.CreateRefreshTokenAsync("user-42", "user", null, null);
+
+            SessionRevocationResult result = await refreshService.InvalidateAllSessionsAsync("user-42");
+
+            Assert.AreEqual("user-42", result.Subject);
+            Assert.AreEqual(1, result.InvalidatedFamilyCount);
+        }
+
+        [TestMethod]
+        public void DefaultInterfaceMethods_ShouldBeCallableAsNoOps()
+        {
+            // Verifies that a consumer implementing only the method(s) they care about does not have to
+            // implement the others — the default interface methods are no-ops that complete successfully.
+            MinimalAuditLogger logger = new MinimalAuditLogger();
+            IAuthAuditLogger asInterface = logger;
+
+            DefaultHttpContext httpContext = new DefaultHttpContext();
+
+            Assert.IsTrue(asInterface.OnLoginAsync(httpContext, LoginResult.Failed(LoginFailureReason.InvalidCredentials)).IsCompletedSuccessfully);
+            Assert.IsTrue(asInterface.OnApiKeyAuthAsync(httpContext, ApiKeyAuthResult.Failed(ApiKeyAuthFailureReason.UnknownKey)).IsCompletedSuccessfully);
+            Assert.IsTrue(asInterface.OnRefreshAsync(httpContext, RefreshResult.Failed(RefreshFailureReason.TokenExpired)).IsCompletedSuccessfully);
+            Assert.IsTrue(asInterface.OnLogoutAsync(httpContext, LogoutResult.Unknown()).IsCompletedSuccessfully);
+        }
+
+        private sealed class MinimalAuditLogger : IAuthAuditLogger
+        {
+            // Implements the interface without overriding any default methods.
+        }
+    }
+}

--- a/EasyReasy.Auth.Tests/AuthAuditLoggerEndpointTests.cs
+++ b/EasyReasy.Auth.Tests/AuthAuditLoggerEndpointTests.cs
@@ -1,0 +1,246 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+
+namespace EasyReasy.Auth.Tests
+{
+    /// <summary>
+    /// Integration tests that spin up an in-process <see cref="TestServer"/> hosting the real endpoint
+    /// extensions (<see cref="AuthApplicationBuilderExtensions.AddAuthEndpoints"/>) and verify that a
+    /// registered <see cref="IAuthAuditLogger"/> receives exactly one hook invocation per endpoint hit,
+    /// on both the success and failure paths, with the right structured data.
+    /// </summary>
+    [TestClass]
+    public class AuthAuditLoggerEndpointTests
+    {
+        private const string Secret = "super_secret_key_12345_12345_12345";
+
+        [TestMethod]
+        public async Task LoginEndpoint_OnSuccess_ShouldInvokeOnLoginAsyncWithSucceededResult()
+        {
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            await using HostedApp host = await HostedApp.StartAsync(auditLogger, new StubValidationService(succeed: true));
+
+            HttpResponseMessage response = await host.Client.PostAsJsonAsync(
+                "/api/auth/login", new LoginAuthRequest("alice", "correct-horse"));
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual(1, auditLogger.LoginCalls.Count);
+            Assert.IsTrue(auditLogger.LoginCalls[0].Result.Success);
+            Assert.AreEqual("alice", auditLogger.LoginCalls[0].Result.AttemptedSubject);
+        }
+
+        [TestMethod]
+        public async Task LoginEndpoint_OnFailure_ShouldInvokeOnLoginAsyncWithFailedResultAndAttemptedSubject()
+        {
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            await using HostedApp host = await HostedApp.StartAsync(auditLogger, new StubValidationService(succeed: false));
+
+            HttpResponseMessage response = await host.Client.PostAsJsonAsync(
+                "/api/auth/login", new LoginAuthRequest("mallory", "wrong"));
+
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.AreEqual(1, auditLogger.LoginCalls.Count);
+            Assert.IsFalse(auditLogger.LoginCalls[0].Result.Success);
+            Assert.AreEqual("mallory", auditLogger.LoginCalls[0].Result.AttemptedSubject);
+            Assert.AreEqual(LoginFailureReason.InvalidCredentials, auditLogger.LoginCalls[0].Result.FailureReason);
+        }
+
+        [TestMethod]
+        public async Task ApiKeyEndpoint_OnSuccess_ShouldInvokeOnApiKeyAuthAsync()
+        {
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            await using HostedApp host = await HostedApp.StartAsync(auditLogger, new StubValidationService(succeed: true));
+
+            HttpResponseMessage response = await host.Client.PostAsJsonAsync(
+                "/api/auth/apikey", new ApiKeyAuthRequest("valid-key"));
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual(1, auditLogger.ApiKeyCalls.Count);
+            Assert.IsTrue(auditLogger.ApiKeyCalls[0].Result.Success);
+        }
+
+        [TestMethod]
+        public async Task ApiKeyEndpoint_OnFailure_ShouldInvokeOnApiKeyAuthAsyncWithFailedResult()
+        {
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            await using HostedApp host = await HostedApp.StartAsync(auditLogger, new StubValidationService(succeed: false));
+
+            HttpResponseMessage response = await host.Client.PostAsJsonAsync(
+                "/api/auth/apikey", new ApiKeyAuthRequest("bad-key"));
+
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.AreEqual(1, auditLogger.ApiKeyCalls.Count);
+            Assert.IsFalse(auditLogger.ApiKeyCalls[0].Result.Success);
+            Assert.AreEqual(ApiKeyAuthFailureReason.UnknownKey, auditLogger.ApiKeyCalls[0].Result.FailureReason);
+        }
+
+        [TestMethod]
+        public async Task RefreshEndpoint_WithUnknownToken_ShouldInvokeOnRefreshAsyncWithTokenNotFound()
+        {
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            await using HostedApp host = await HostedApp.StartAsync(auditLogger, new StubValidationService(succeed: true));
+
+            HttpResponseMessage response = await host.Client.PostAsJsonAsync(
+                "/api/auth/refresh", new RefreshRequest("unknown-refresh-token"));
+
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.AreEqual(1, auditLogger.RefreshCalls.Count);
+            Assert.IsFalse(auditLogger.RefreshCalls[0].Result.Success);
+            Assert.AreEqual(RefreshFailureReason.TokenNotFound, auditLogger.RefreshCalls[0].Result.FailureReason);
+        }
+
+        [TestMethod]
+        public async Task LogoutEndpoint_WithUnknownToken_ShouldInvokeOnLogoutAsyncWithUnknownResult()
+        {
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            await using HostedApp host = await HostedApp.StartAsync(auditLogger, new StubValidationService(succeed: true));
+
+            HttpResponseMessage response = await host.Client.PostAsJsonAsync(
+                "/api/auth/logout", new LogoutRequest("unknown-token"));
+
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+            Assert.AreEqual(1, auditLogger.LogoutCalls.Count);
+            Assert.IsFalse(auditLogger.LogoutCalls[0].Result.WasKnown);
+            Assert.IsNotNull(auditLogger.LogoutCalls[0].HttpContext);
+        }
+
+        [TestMethod]
+        public async Task LogoutEndpoint_WithKnownToken_ShouldInvokeOnLogoutAsyncWithKnownResult()
+        {
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            FakeRefreshTokenStore store = new FakeRefreshTokenStore();
+            await using HostedApp host = await HostedApp.StartAsync(auditLogger, new StubValidationService(succeed: true), store);
+
+            // Issue a refresh token via the service layer so we know a valid token exists.
+            IRefreshTokenService refreshService = host.App.Services.GetRequiredService<IRefreshTokenService>();
+            string rawToken = await refreshService.CreateRefreshTokenAsync("user-42", "user", null, null);
+
+            // CreateRefreshTokenAsync does not invoke the audit logger — clear the LogoutCalls for cleanliness
+            // (not strictly needed because CreateRefreshTokenAsync has no hook, but being explicit).
+            auditLogger.LogoutCalls.Clear();
+
+            HttpResponseMessage response = await host.Client.PostAsJsonAsync(
+                "/api/auth/logout", new LogoutRequest(rawToken));
+
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+            Assert.AreEqual(1, auditLogger.LogoutCalls.Count);
+            Assert.IsTrue(auditLogger.LogoutCalls[0].Result.WasKnown);
+            Assert.AreEqual("user-42", auditLogger.LogoutCalls[0].Result.Subject);
+            Assert.IsNotNull(auditLogger.LogoutCalls[0].HttpContext);
+        }
+
+        [TestMethod]
+        public async Task LogoutEndpoint_WithoutRegisteredAuditLogger_ShouldStillReturn204()
+        {
+            await using HostedApp host = await HostedApp.StartAsync(auditLogger: null, new StubValidationService(succeed: true));
+
+            HttpResponseMessage response = await host.Client.PostAsJsonAsync(
+                "/api/auth/logout", new LogoutRequest("anything"));
+
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+        }
+
+        /// <summary>
+        /// Helper that builds a real <see cref="WebApplication"/> with the library's own
+        /// <see cref="AuthApplicationBuilderExtensions.AddAuthEndpoints"/> and exposes a
+        /// <see cref="TestServer"/>-backed <see cref="HttpClient"/>.
+        /// </summary>
+        private sealed class HostedApp : IAsyncDisposable
+        {
+            public WebApplication App { get; }
+            public HttpClient Client { get; }
+
+            private HostedApp(WebApplication app, HttpClient client)
+            {
+                App = app;
+                Client = client;
+            }
+
+            public static async Task<HostedApp> StartAsync(
+                RecordingAuditLogger? auditLogger,
+                IAuthRequestValidationService validationService,
+                FakeRefreshTokenStore? store = null)
+            {
+                WebApplicationBuilder builder = WebApplication.CreateBuilder();
+                builder.WebHost.UseTestServer();
+                builder.Logging.ClearProviders();
+
+                builder.Services.AddEasyReasyAuth(Secret);
+                builder.Services.AddSingleton<IAuthRequestValidationService>(validationService);
+
+                FakeRefreshTokenStore sharedStore = store ?? new FakeRefreshTokenStore();
+                builder.Services.AddSingleton<IRefreshTokenStore>(sharedStore);
+                builder.Services.AddSingleton<IRefreshTokenService>(provider =>
+                    new RefreshTokenService(
+                        provider.GetRequiredService<IRefreshTokenStore>(),
+                        auditLogger: provider.GetService<IAuthAuditLogger>()));
+
+                if (auditLogger != null)
+                {
+                    builder.Services.AddSingleton<IAuthAuditLogger>(auditLogger);
+                }
+
+                WebApplication app = builder.Build();
+                app.UseEasyReasyAuth(options => options.Enabled = false);
+                app.AddAuthEndpoints(allowRefresh: true, allowLogout: true);
+
+                await app.StartAsync();
+                TestServer server = (TestServer)app.Services.GetRequiredService<IServer>();
+                HttpClient client = server.CreateClient();
+                return new HostedApp(app, client);
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                try
+                {
+                    Client.Dispose();
+                }
+                finally
+                {
+                    await App.DisposeAsync();
+                }
+            }
+        }
+
+        private sealed class StubValidationService : IAuthRequestValidationService
+        {
+            private readonly bool _succeed;
+
+            public StubValidationService(bool succeed)
+            {
+                _succeed = succeed;
+            }
+
+            public Task<ApiKeyAuthResult> ValidateApiKeyRequestAsync(ApiKeyAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
+            {
+                if (_succeed)
+                {
+                    DateTime expiresAt = DateTime.UtcNow.AddHours(1);
+                    string token = jwtTokenService.CreateToken("test-client", "apikey", new List<Claim>(), new List<string>(), expiresAt);
+                    return Task.FromResult(ApiKeyAuthResult.Succeeded(new AuthResponse(token, expiresAt.ToString("o")), "test-client"));
+                }
+                return Task.FromResult(ApiKeyAuthResult.Failed(ApiKeyAuthFailureReason.UnknownKey, attemptedClientId: request.ApiKey));
+            }
+
+            public Task<LoginResult> ValidateLoginRequestAsync(LoginAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
+            {
+                if (_succeed)
+                {
+                    DateTime expiresAt = DateTime.UtcNow.AddHours(1);
+                    string token = jwtTokenService.CreateToken(request.Username, "user", new List<Claim>(), new List<string>(), expiresAt);
+                    return Task.FromResult(LoginResult.Succeeded(new AuthResponse(token, expiresAt.ToString("o")), request.Username));
+                }
+                return Task.FromResult(LoginResult.Failed(LoginFailureReason.InvalidCredentials, attemptedSubject: request.Username));
+            }
+        }
+    }
+}

--- a/EasyReasy.Auth.Tests/EasyReasy.Auth.Tests.csproj
+++ b/EasyReasy.Auth.Tests/EasyReasy.Auth.Tests.csproj
@@ -10,7 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.3.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.12" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.12.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />

--- a/EasyReasy.Auth.Tests/FakeRefreshTokenStore.cs
+++ b/EasyReasy.Auth.Tests/FakeRefreshTokenStore.cs
@@ -7,19 +7,19 @@ namespace EasyReasy.Auth.Tests
     {
         private readonly Dictionary<string, StoredRefreshToken> _tokens = new Dictionary<string, StoredRefreshToken>();
 
-        public Task StoreAsync(StoredRefreshToken refreshToken)
+        public Task StoreAsync(StoredRefreshToken refreshToken, CancellationToken cancellationToken = default)
         {
             _tokens[refreshToken.TokenHash] = refreshToken;
             return Task.CompletedTask;
         }
 
-        public Task<StoredRefreshToken?> GetByTokenHashAsync(string tokenHash)
+        public Task<StoredRefreshToken?> GetByTokenHashAsync(string tokenHash, CancellationToken cancellationToken = default)
         {
             _tokens.TryGetValue(tokenHash, out StoredRefreshToken? token);
             return Task.FromResult(token);
         }
 
-        public Task<bool> MarkAsConsumedAsync(string tokenHash, DateTime consumedAt)
+        public Task<bool> MarkAsConsumedAsync(string tokenHash, DateTime consumedAt, CancellationToken cancellationToken = default)
         {
             if (_tokens.TryGetValue(tokenHash, out StoredRefreshToken? token))
             {
@@ -34,11 +34,23 @@ namespace EasyReasy.Auth.Tests
             return Task.FromResult(false);
         }
 
-        public Task InvalidateFamilyAsync(string familyId)
+        public Task InvalidateFamilyAsync(string familyId, CancellationToken cancellationToken = default)
         {
             foreach (StoredRefreshToken token in _tokens.Values)
             {
                 if (token.FamilyId == familyId)
+                {
+                    token.IsInvalidated = true;
+                }
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task InvalidateAllFamiliesForUserAsync(string subject, CancellationToken cancellationToken = default)
+        {
+            foreach (StoredRefreshToken token in _tokens.Values)
+            {
+                if (token.Subject == subject && !token.IsInvalidated)
                 {
                     token.IsInvalidated = true;
                 }

--- a/EasyReasy.Auth.Tests/FakeRefreshTokenStore.cs
+++ b/EasyReasy.Auth.Tests/FakeRefreshTokenStore.cs
@@ -46,16 +46,18 @@ namespace EasyReasy.Auth.Tests
             return Task.CompletedTask;
         }
 
-        public Task InvalidateAllFamiliesForUserAsync(string subject, CancellationToken cancellationToken = default)
+        public Task<int> InvalidateAllFamiliesForUserAsync(string subject, CancellationToken cancellationToken = default)
         {
+            HashSet<string> invalidatedFamilies = new HashSet<string>();
             foreach (StoredRefreshToken token in _tokens.Values)
             {
                 if (token.Subject == subject && !token.IsInvalidated)
                 {
                     token.IsInvalidated = true;
+                    invalidatedFamilies.Add(token.FamilyId);
                 }
             }
-            return Task.CompletedTask;
+            return Task.FromResult(invalidatedFamilies.Count);
         }
 
         /// <summary>

--- a/EasyReasy.Auth.Tests/HttpContextValidationTests.cs
+++ b/EasyReasy.Auth.Tests/HttpContextValidationTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
+using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 
 namespace EasyReasy.Auth.Tests
@@ -11,7 +12,7 @@ namespace EasyReasy.Auth.Tests
         private const string Issuer = "test-issuer";
 
         [TestMethod]
-        public void ValidateApiKeyRequestAsync_WithHttpContext_ShouldExtractHeaders()
+        public async Task ValidateApiKeyRequestAsync_WithHttpContext_ShouldExtractHeaders()
         {
             // Arrange
             TestHttpContextValidationService validationService = new TestHttpContextValidationService();
@@ -23,15 +24,16 @@ namespace EasyReasy.Auth.Tests
             httpContext.Request.QueryString = new QueryString("?org=test-org");
 
             // Act
-            AuthResponse? response = validationService.ValidateApiKeyRequestAsync(request, jwtTokenService, httpContext).Result;
+            ApiKeyAuthResult result = await validationService.ValidateApiKeyRequestAsync(request, jwtTokenService, httpContext);
 
             // Assert
-            Assert.IsNotNull(response);
-            Assert.IsNotNull(response.Token);
+            Assert.IsTrue(result.Success);
+            Assert.IsNotNull(result.AuthResponse);
+            Assert.IsNotNull(result.AuthResponse.Token);
 
             // Verify the token contains the extracted header information
-            System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler handler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
-            System.IdentityModel.Tokens.Jwt.JwtSecurityToken token = handler.ReadJwtToken(response.Token);
+            JwtSecurityTokenHandler handler = new JwtSecurityTokenHandler();
+            JwtSecurityToken token = handler.ReadJwtToken(result.AuthResponse.Token);
 
             Claim? tenantClaim = token.Claims.FirstOrDefault(c => c.Type == "tenant_id");
             Assert.IsNotNull(tenantClaim);
@@ -39,7 +41,7 @@ namespace EasyReasy.Auth.Tests
         }
 
         [TestMethod]
-        public void ValidateLoginRequestAsync_WithHttpContext_ShouldExtractHeaders()
+        public async Task ValidateLoginRequestAsync_WithHttpContext_ShouldExtractHeaders()
         {
             // Arrange
             TestHttpContextValidationService validationService = new TestHttpContextValidationService();
@@ -51,15 +53,16 @@ namespace EasyReasy.Auth.Tests
             httpContext.Request.QueryString = new QueryString("?org=test-org");
 
             // Act
-            AuthResponse? response = validationService.ValidateLoginRequestAsync(request, jwtTokenService, httpContext).Result;
+            LoginResult result = await validationService.ValidateLoginRequestAsync(request, jwtTokenService, httpContext);
 
             // Assert
-            Assert.IsNotNull(response);
-            Assert.IsNotNull(response.Token);
+            Assert.IsTrue(result.Success);
+            Assert.IsNotNull(result.AuthResponse);
+            Assert.IsNotNull(result.AuthResponse.Token);
 
             // Verify the token contains the extracted header information
-            System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler handler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
-            System.IdentityModel.Tokens.Jwt.JwtSecurityToken token = handler.ReadJwtToken(response.Token);
+            JwtSecurityTokenHandler handler = new JwtSecurityTokenHandler();
+            JwtSecurityToken token = handler.ReadJwtToken(result.AuthResponse.Token);
 
             Claim? tenantClaim = token.Claims.FirstOrDefault(c => c.Type == "tenant_id");
             Assert.IsNotNull(tenantClaim);
@@ -67,7 +70,7 @@ namespace EasyReasy.Auth.Tests
         }
 
         [TestMethod]
-        public void ValidateApiKeyRequestAsync_WithoutHttpContext_ShouldWorkBackwardCompatible()
+        public async Task ValidateApiKeyRequestAsync_WithoutHttpContext_ShouldWorkBackwardCompatible()
         {
             // Arrange
             TestHttpContextValidationService validationService = new TestHttpContextValidationService();
@@ -75,15 +78,16 @@ namespace EasyReasy.Auth.Tests
             ApiKeyAuthRequest request = new ApiKeyAuthRequest("test-api-key");
 
             // Act
-            AuthResponse? response = validationService.ValidateApiKeyRequestAsync(request, jwtTokenService, null).Result;
+            ApiKeyAuthResult result = await validationService.ValidateApiKeyRequestAsync(request, jwtTokenService, null);
 
             // Assert
-            Assert.IsNotNull(response);
-            Assert.IsNotNull(response.Token);
+            Assert.IsTrue(result.Success);
+            Assert.IsNotNull(result.AuthResponse);
+            Assert.IsNotNull(result.AuthResponse.Token);
 
             // Verify the token contains default tenant information
-            System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler handler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
-            System.IdentityModel.Tokens.Jwt.JwtSecurityToken token = handler.ReadJwtToken(response.Token);
+            JwtSecurityTokenHandler handler = new JwtSecurityTokenHandler();
+            JwtSecurityToken token = handler.ReadJwtToken(result.AuthResponse.Token);
 
             Claim? tenantClaim = token.Claims.FirstOrDefault(c => c.Type == "tenant_id");
             Assert.IsNotNull(tenantClaim);
@@ -91,7 +95,7 @@ namespace EasyReasy.Auth.Tests
         }
 
         [TestMethod]
-        public void ValidateLoginRequestAsync_WithoutHttpContext_ShouldWorkBackwardCompatible()
+        public async Task ValidateLoginRequestAsync_WithoutHttpContext_ShouldWorkBackwardCompatible()
         {
             // Arrange
             TestHttpContextValidationService validationService = new TestHttpContextValidationService();
@@ -99,15 +103,16 @@ namespace EasyReasy.Auth.Tests
             LoginAuthRequest request = new LoginAuthRequest("test-user", "test-password");
 
             // Act
-            AuthResponse? response = validationService.ValidateLoginRequestAsync(request, jwtTokenService, null).Result;
+            LoginResult result = await validationService.ValidateLoginRequestAsync(request, jwtTokenService, null);
 
             // Assert
-            Assert.IsNotNull(response);
-            Assert.IsNotNull(response.Token);
+            Assert.IsTrue(result.Success);
+            Assert.IsNotNull(result.AuthResponse);
+            Assert.IsNotNull(result.AuthResponse.Token);
 
             // Verify the token contains default tenant information
-            System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler handler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
-            System.IdentityModel.Tokens.Jwt.JwtSecurityToken token = handler.ReadJwtToken(response.Token);
+            JwtSecurityTokenHandler handler = new JwtSecurityTokenHandler();
+            JwtSecurityToken token = handler.ReadJwtToken(result.AuthResponse.Token);
 
             Claim? tenantClaim = token.Claims.FirstOrDefault(c => c.Type == "tenant_id");
             Assert.IsNotNull(tenantClaim);
@@ -116,7 +121,7 @@ namespace EasyReasy.Auth.Tests
 
         private class TestHttpContextValidationService : IAuthRequestValidationService
         {
-            public Task<AuthResponse?> ValidateApiKeyRequestAsync(ApiKeyAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
+            public Task<ApiKeyAuthResult> ValidateApiKeyRequestAsync(ApiKeyAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
             {
                 // Extract tenant ID from header if available
                 string tenantId = "default-tenant";
@@ -134,10 +139,10 @@ namespace EasyReasy.Auth.Tests
                     roles: new[] { "user" },
                     expiresAt: expiresAt);
 
-                return Task.FromResult<AuthResponse?>(new AuthResponse(token, expiresAt.ToString("o")));
+                return Task.FromResult(ApiKeyAuthResult.Succeeded(new AuthResponse(token, expiresAt.ToString("o")), "test-user"));
             }
 
-            public Task<AuthResponse?> ValidateLoginRequestAsync(LoginAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
+            public Task<LoginResult> ValidateLoginRequestAsync(LoginAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
             {
                 // Extract tenant ID from header if available
                 string tenantId = "default-tenant";
@@ -155,7 +160,7 @@ namespace EasyReasy.Auth.Tests
                     roles: new[] { "user" },
                     expiresAt: expiresAt);
 
-                return Task.FromResult<AuthResponse?>(new AuthResponse(token, expiresAt.ToString("o")));
+                return Task.FromResult(LoginResult.Succeeded(new AuthResponse(token, expiresAt.ToString("o")), "test-user"));
             }
         }
     }

--- a/EasyReasy.Auth.Tests/LoginResultTests.cs
+++ b/EasyReasy.Auth.Tests/LoginResultTests.cs
@@ -1,0 +1,56 @@
+namespace EasyReasy.Auth.Tests
+{
+    [TestClass]
+    public class LoginResultTests
+    {
+        [TestMethod]
+        public void Succeeded_ShouldCreateSuccessfulResult()
+        {
+            AuthResponse authResponse = new AuthResponse("jwt-token", "2025-01-01T00:00:00Z");
+
+            LoginResult result = LoginResult.Succeeded(authResponse, "user-42");
+
+            Assert.IsTrue(result.Success);
+            Assert.AreSame(authResponse, result.AuthResponse);
+            Assert.AreEqual("user-42", result.AttemptedSubject);
+            Assert.IsNull(result.FailureReason);
+        }
+
+        [TestMethod]
+        public void Failed_ShouldCreateFailedResult()
+        {
+            LoginResult result = LoginResult.Failed(LoginFailureReason.InvalidCredentials);
+
+            Assert.IsFalse(result.Success);
+            Assert.IsNull(result.AuthResponse);
+            Assert.AreEqual(LoginFailureReason.InvalidCredentials, result.FailureReason);
+        }
+
+        [TestMethod]
+        public void Failed_WithoutAttemptedSubject_ShouldDefaultToNull()
+        {
+            LoginResult result = LoginResult.Failed(LoginFailureReason.UnknownUser);
+
+            Assert.IsNull(result.AttemptedSubject);
+        }
+
+        [TestMethod]
+        public void Failed_WithAttemptedSubject_ShouldPopulateIt()
+        {
+            LoginResult result = LoginResult.Failed(LoginFailureReason.UnknownUser, attemptedSubject: "ghost-user");
+
+            Assert.AreEqual("ghost-user", result.AttemptedSubject);
+            Assert.AreEqual(LoginFailureReason.UnknownUser, result.FailureReason);
+        }
+
+        [TestMethod]
+        public void Failed_WithEachReason_ShouldSetReasonCorrectly()
+        {
+            Assert.AreEqual(LoginFailureReason.UnknownUser, LoginResult.Failed(LoginFailureReason.UnknownUser).FailureReason);
+            Assert.AreEqual(LoginFailureReason.InvalidCredentials, LoginResult.Failed(LoginFailureReason.InvalidCredentials).FailureReason);
+            Assert.AreEqual(LoginFailureReason.UserDisabled, LoginResult.Failed(LoginFailureReason.UserDisabled).FailureReason);
+            Assert.AreEqual(LoginFailureReason.UserLocked, LoginResult.Failed(LoginFailureReason.UserLocked).FailureReason);
+            Assert.AreEqual(LoginFailureReason.Other, LoginResult.Failed(LoginFailureReason.Other).FailureReason);
+        }
+    }
+}

--- a/EasyReasy.Auth.Tests/LogoutRequestTests.cs
+++ b/EasyReasy.Auth.Tests/LogoutRequestTests.cs
@@ -1,0 +1,58 @@
+namespace EasyReasy.Auth.Tests
+{
+    [TestClass]
+    public class LogoutRequestTests
+    {
+        [TestMethod]
+        public void ToJson_ShouldSerializeCorrectly()
+        {
+            LogoutRequest request = new LogoutRequest("my-refresh-token");
+
+            string json = request.ToJson();
+
+            Assert.IsTrue(json.Contains("refreshToken"));
+            Assert.IsTrue(json.Contains("my-refresh-token"));
+        }
+
+        [TestMethod]
+        public void FromJson_ShouldDeserializeCorrectly()
+        {
+            LogoutRequest original = new LogoutRequest("my-refresh-token");
+            string json = original.ToJson();
+
+            LogoutRequest deserialized = LogoutRequest.FromJson(json);
+
+            Assert.AreEqual("my-refresh-token", deserialized.RefreshToken);
+        }
+
+        [TestMethod]
+        public void ToString_ShouldRedactRefreshToken()
+        {
+            LogoutRequest request = new LogoutRequest("my-refresh-token");
+
+            string result = request.ToString();
+
+            Assert.IsTrue(result.Contains("[REDACTED]"));
+            Assert.IsFalse(result.Contains("my-refresh-token"));
+        }
+
+        [TestMethod]
+        public void FromJson_WithInvalidJson_ShouldNotLeakInputInException()
+        {
+            string sensitiveJson = "{\"refreshToken\":\"secret-token-value\",invalid}";
+
+            ArgumentException exception = Assert.ThrowsException<ArgumentException>(
+                () => LogoutRequest.FromJson(sensitiveJson));
+
+            Assert.IsFalse(exception.Message.Contains("secret-token-value"));
+            Assert.IsNull(exception.InnerException);
+        }
+
+        [TestMethod]
+        public void FromJson_WithInvalidJson_ShouldThrowArgumentException()
+        {
+            Assert.ThrowsException<ArgumentException>(
+                () => LogoutRequest.FromJson("not-valid-json"));
+        }
+    }
+}

--- a/EasyReasy.Auth.Tests/LogoutResultTests.cs
+++ b/EasyReasy.Auth.Tests/LogoutResultTests.cs
@@ -1,0 +1,26 @@
+namespace EasyReasy.Auth.Tests
+{
+    [TestClass]
+    public class LogoutResultTests
+    {
+        [TestMethod]
+        public void Known_ShouldPopulateSubjectAndFamilyId()
+        {
+            LogoutResult result = LogoutResult.Known("user-42", "family-abc");
+
+            Assert.IsTrue(result.WasKnown);
+            Assert.AreEqual("user-42", result.Subject);
+            Assert.AreEqual("family-abc", result.FamilyId);
+        }
+
+        [TestMethod]
+        public void Unknown_ShouldHaveNullSubjectAndFamilyId()
+        {
+            LogoutResult result = LogoutResult.Unknown();
+
+            Assert.IsFalse(result.WasKnown);
+            Assert.IsNull(result.Subject);
+            Assert.IsNull(result.FamilyId);
+        }
+    }
+}

--- a/EasyReasy.Auth.Tests/RecordingAuditLogger.cs
+++ b/EasyReasy.Auth.Tests/RecordingAuditLogger.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Http;
+
+namespace EasyReasy.Auth.Tests
+{
+    /// <summary>
+    /// In-memory <see cref="IAuthAuditLogger"/> that records every hook invocation so tests can
+    /// assert which events fired and with what data. Used across multiple test classes.
+    /// </summary>
+    internal sealed class RecordingAuditLogger : IAuthAuditLogger
+    {
+        public List<(HttpContext HttpContext, LoginResult Result)> LoginCalls { get; } = new List<(HttpContext, LoginResult)>();
+        public List<(HttpContext HttpContext, ApiKeyAuthResult Result)> ApiKeyCalls { get; } = new List<(HttpContext, ApiKeyAuthResult)>();
+        public List<(HttpContext? HttpContext, RefreshResult Result)> RefreshCalls { get; } = new List<(HttpContext?, RefreshResult)>();
+        public List<(HttpContext? HttpContext, LogoutResult Result)> LogoutCalls { get; } = new List<(HttpContext?, LogoutResult)>();
+        public List<SessionRevocationResult> SessionsInvalidatedCalls { get; } = new List<SessionRevocationResult>();
+
+        public Task OnLoginAsync(HttpContext httpContext, LoginResult result)
+        {
+            LoginCalls.Add((httpContext, result));
+            return Task.CompletedTask;
+        }
+
+        public Task OnApiKeyAuthAsync(HttpContext httpContext, ApiKeyAuthResult result)
+        {
+            ApiKeyCalls.Add((httpContext, result));
+            return Task.CompletedTask;
+        }
+
+        public Task OnRefreshAsync(HttpContext? httpContext, RefreshResult result)
+        {
+            RefreshCalls.Add((httpContext, result));
+            return Task.CompletedTask;
+        }
+
+        public Task OnLogoutAsync(HttpContext? httpContext, LogoutResult result)
+        {
+            LogoutCalls.Add((httpContext, result));
+            return Task.CompletedTask;
+        }
+
+        public Task OnSessionsInvalidatedAsync(SessionRevocationResult result)
+        {
+            SessionsInvalidatedCalls.Add(result);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/EasyReasy.Auth.Tests/RefreshResultTests.cs
+++ b/EasyReasy.Auth.Tests/RefreshResultTests.cs
@@ -17,6 +17,32 @@ namespace EasyReasy.Auth.Tests
         }
 
         [TestMethod]
+        public void Succeeded_WithoutSubjectOrFamilyId_ShouldDefaultToNull()
+        {
+            AuthResponse authResponse = new AuthResponse("jwt-token", "2025-01-01T00:00:00Z", "new-refresh-token");
+
+            RefreshResult result = RefreshResult.Succeeded(authResponse, "new-refresh-token");
+
+            Assert.IsNull(result.Subject);
+            Assert.IsNull(result.FamilyId);
+        }
+
+        [TestMethod]
+        public void Succeeded_WithSubjectAndFamilyId_ShouldPopulateBoth()
+        {
+            AuthResponse authResponse = new AuthResponse("jwt-token", "2025-01-01T00:00:00Z", "new-refresh-token");
+
+            RefreshResult result = RefreshResult.Succeeded(
+                authResponse,
+                "new-refresh-token",
+                subject: "user-42",
+                familyId: "family-abc");
+
+            Assert.AreEqual("user-42", result.Subject);
+            Assert.AreEqual("family-abc", result.FamilyId);
+        }
+
+        [TestMethod]
         public void Failed_ShouldCreateFailedResult()
         {
             RefreshResult result = RefreshResult.Failed(RefreshFailureReason.TokenExpired);
@@ -25,6 +51,27 @@ namespace EasyReasy.Auth.Tests
             Assert.IsNull(result.AuthResponse);
             Assert.IsNull(result.NewRefreshToken);
             Assert.AreEqual(RefreshFailureReason.TokenExpired, result.FailureReason);
+        }
+
+        [TestMethod]
+        public void Failed_WithoutSubjectOrFamilyId_ShouldDefaultToNull()
+        {
+            RefreshResult result = RefreshResult.Failed(RefreshFailureReason.TokenNotFound);
+
+            Assert.IsNull(result.Subject);
+            Assert.IsNull(result.FamilyId);
+        }
+
+        [TestMethod]
+        public void Failed_WithSubjectAndFamilyId_ShouldPopulateBoth()
+        {
+            RefreshResult result = RefreshResult.Failed(
+                RefreshFailureReason.TheftDetected,
+                subject: "user-42",
+                familyId: "family-abc");
+
+            Assert.AreEqual("user-42", result.Subject);
+            Assert.AreEqual("family-abc", result.FamilyId);
         }
 
         [TestMethod]

--- a/EasyReasy.Auth.Tests/RefreshTokenServiceTests.cs
+++ b/EasyReasy.Auth.Tests/RefreshTokenServiceTests.cs
@@ -288,7 +288,7 @@ namespace EasyReasy.Auth.Tests
         [TestMethod]
         public async Task LogoutAsync_WithNullToken_ShouldCompleteSilently()
         {
-            await _service.LogoutAsync(null!);
+            await _service.LogoutAsync(null);
 
             Assert.AreEqual(0, _store.Tokens.Count);
         }
@@ -402,7 +402,7 @@ namespace EasyReasy.Auth.Tests
         }
 
         [TestMethod]
-        public async Task InvalidateAllSessionsAsync_WithNoSessions_ShouldCompleteSilently()
+        public async Task InvalidateAllSessionsAsync_WithNoSessions_ShouldNotMutateStore()
         {
             await _service.InvalidateAllSessionsAsync("user-with-no-tokens");
 
@@ -420,12 +420,16 @@ namespace EasyReasy.Auth.Tests
                 currentToken = result.NewRefreshToken!;
             }
 
-            await _service.InvalidateAllSessionsAsync("user-1");
+            SessionRevocationResult revocation = await _service.InvalidateAllSessionsAsync("user-1");
 
             foreach (StoredRefreshToken token in _store.Tokens.Values)
             {
                 Assert.IsTrue(token.IsInvalidated);
             }
+
+            // Three rotations put four tokens into one family, so the family count should be 1
+            // even though four individual token rows are invalidated.
+            Assert.AreEqual(1, revocation.InvalidatedFamilyCount);
         }
 
         [TestMethod]
@@ -499,6 +503,128 @@ namespace EasyReasy.Auth.Tests
             Assert.AreEqual(RefreshFailureReason.TheftDetected, replayResult.FailureReason);
             Assert.AreEqual("user-1", replayResult.Subject);
             Assert.AreEqual(expectedFamilyId, replayResult.FamilyId);
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_WithKnownToken_ShouldReturnKnownResultWithSubjectAndFamilyId()
+        {
+            string rawToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string hash = RefreshTokenService.HashToken(rawToken);
+            string expectedFamilyId = _store.Tokens[hash].FamilyId;
+
+            LogoutResult result = await _service.LogoutAsync(rawToken);
+
+            Assert.IsTrue(result.WasKnown);
+            Assert.AreEqual("user-1", result.Subject);
+            Assert.AreEqual(expectedFamilyId, result.FamilyId);
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_WithNullToken_ShouldReturnUnknownResult()
+        {
+            LogoutResult result = await _service.LogoutAsync(null);
+
+            Assert.IsFalse(result.WasKnown);
+            Assert.IsNull(result.Subject);
+            Assert.IsNull(result.FamilyId);
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_WithEmptyToken_ShouldReturnUnknownResult()
+        {
+            LogoutResult result = await _service.LogoutAsync(string.Empty);
+
+            Assert.IsFalse(result.WasKnown);
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_WithNonexistentToken_ShouldReturnUnknownResult()
+        {
+            LogoutResult result = await _service.LogoutAsync("nonexistent-token");
+
+            Assert.IsFalse(result.WasKnown);
+        }
+
+        [TestMethod]
+        public async Task InvalidateAllSessionsAsync_ShouldReturnSubjectAndCountOfInvalidatedFamilies()
+        {
+            await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            await _service.CreateRefreshTokenAsync("user-2", "user", null, null);
+
+            SessionRevocationResult result = await _service.InvalidateAllSessionsAsync("user-1");
+
+            Assert.AreEqual("user-1", result.Subject);
+            Assert.AreEqual(3, result.InvalidatedFamilyCount);
+        }
+
+        [TestMethod]
+        public async Task InvalidateAllSessionsAsync_WithNoSessions_ShouldReturnZeroCount()
+        {
+            SessionRevocationResult result = await _service.InvalidateAllSessionsAsync("user-with-no-tokens");
+
+            Assert.AreEqual("user-with-no-tokens", result.Subject);
+            Assert.AreEqual(0, result.InvalidatedFamilyCount);
+        }
+
+        [TestMethod]
+        public async Task InvalidateAllSessionsAsync_AfterRotations_ShouldCountFamiliesNotIndividualTokens()
+        {
+            string currentToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            for (int i = 0; i < 3; i++)
+            {
+                RefreshResult r = await _service.RefreshAsync(currentToken, _jwtTokenService);
+                currentToken = r.NewRefreshToken!;
+            }
+
+            SessionRevocationResult result = await _service.InvalidateAllSessionsAsync("user-1");
+
+            Assert.AreEqual(1, result.InvalidatedFamilyCount);
+        }
+
+        [TestMethod]
+        public async Task InvalidateAllSessionsAsync_WithAuditLogger_ShouldInvokeOnSessionsInvalidatedAsync()
+        {
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            RefreshTokenService serviceWithAuditor = new RefreshTokenService(_store, auditLogger: auditLogger);
+
+            await serviceWithAuditor.CreateRefreshTokenAsync("user-1", "user", null, null);
+            await serviceWithAuditor.CreateRefreshTokenAsync("user-1", "user", null, null);
+
+            SessionRevocationResult result = await serviceWithAuditor.InvalidateAllSessionsAsync("user-1");
+
+            Assert.AreEqual(1, auditLogger.SessionsInvalidatedCalls.Count);
+            Assert.AreSame(result, auditLogger.SessionsInvalidatedCalls[0]);
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_ProgrammaticCall_ShouldInvokeOnLogoutAsyncWithNullHttpContext()
+        {
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            RefreshTokenService serviceWithAuditor = new RefreshTokenService(_store, auditLogger: auditLogger);
+
+            string rawToken = await serviceWithAuditor.CreateRefreshTokenAsync("user-1", "user", null, null);
+
+            LogoutResult result = await serviceWithAuditor.LogoutAsync(rawToken);
+
+            Assert.AreEqual(1, auditLogger.LogoutCalls.Count);
+            Assert.IsNull(auditLogger.LogoutCalls[0].HttpContext);
+            Assert.AreSame(result, auditLogger.LogoutCalls[0].Result);
+            Assert.IsTrue(result.WasKnown);
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_WithUnknownToken_ShouldStillInvokeOnLogoutAsync()
+        {
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            RefreshTokenService serviceWithAuditor = new RefreshTokenService(_store, auditLogger: auditLogger);
+
+            LogoutResult result = await serviceWithAuditor.LogoutAsync("nonexistent-token");
+
+            Assert.AreEqual(1, auditLogger.LogoutCalls.Count);
+            Assert.IsFalse(result.WasKnown);
+            Assert.IsFalse(auditLogger.LogoutCalls[0].Result.WasKnown);
         }
     }
 }

--- a/EasyReasy.Auth.Tests/RefreshTokenServiceTests.cs
+++ b/EasyReasy.Auth.Tests/RefreshTokenServiceTests.cs
@@ -427,5 +427,78 @@ namespace EasyReasy.Auth.Tests
                 Assert.IsTrue(token.IsInvalidated);
             }
         }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithValidToken_ShouldPopulateSubjectAndFamilyIdOnResult()
+        {
+            string rawToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string hash = RefreshTokenService.HashToken(rawToken);
+            string expectedFamilyId = _store.Tokens[hash].FamilyId;
+
+            RefreshResult result = await _service.RefreshAsync(rawToken, _jwtTokenService);
+
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual("user-1", result.Subject);
+            Assert.AreEqual(expectedFamilyId, result.FamilyId);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithNonexistentToken_ShouldReturnNullSubjectAndFamilyId()
+        {
+            RefreshResult result = await _service.RefreshAsync("nonexistent-token", _jwtTokenService);
+
+            Assert.AreEqual(RefreshFailureReason.TokenNotFound, result.FailureReason);
+            Assert.IsNull(result.Subject);
+            Assert.IsNull(result.FamilyId);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithInvalidatedToken_ShouldPopulateSubjectAndFamilyIdOnResult()
+        {
+            string rawToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string hash = RefreshTokenService.HashToken(rawToken);
+            string expectedFamilyId = _store.Tokens[hash].FamilyId;
+
+            await _store.InvalidateFamilyAsync(expectedFamilyId);
+
+            RefreshResult result = await _service.RefreshAsync(rawToken, _jwtTokenService);
+
+            Assert.AreEqual(RefreshFailureReason.TokenInvalidated, result.FailureReason);
+            Assert.AreEqual("user-1", result.Subject);
+            Assert.AreEqual(expectedFamilyId, result.FamilyId);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithExpiredToken_ShouldPopulateSubjectAndFamilyIdOnResult()
+        {
+            RefreshTokenService shortLivedService = new RefreshTokenService(_store, refreshTokenLifetime: TimeSpan.FromMilliseconds(1));
+            string rawToken = await shortLivedService.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string hash = RefreshTokenService.HashToken(rawToken);
+            string expectedFamilyId = _store.Tokens[hash].FamilyId;
+
+            await Task.Delay(50);
+
+            RefreshResult result = await shortLivedService.RefreshAsync(rawToken, _jwtTokenService);
+
+            Assert.AreEqual(RefreshFailureReason.TokenExpired, result.FailureReason);
+            Assert.AreEqual("user-1", result.Subject);
+            Assert.AreEqual(expectedFamilyId, result.FamilyId);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithConsumedToken_ShouldPopulateSubjectAndFamilyIdOnTheftResult()
+        {
+            string rawToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string hash = RefreshTokenService.HashToken(rawToken);
+            string expectedFamilyId = _store.Tokens[hash].FamilyId;
+
+            await _service.RefreshAsync(rawToken, _jwtTokenService);
+
+            RefreshResult replayResult = await _service.RefreshAsync(rawToken, _jwtTokenService);
+
+            Assert.AreEqual(RefreshFailureReason.TheftDetected, replayResult.FailureReason);
+            Assert.AreEqual("user-1", replayResult.Subject);
+            Assert.AreEqual(expectedFamilyId, replayResult.FamilyId);
+        }
     }
 }

--- a/EasyReasy.Auth.Tests/RefreshTokenServiceTests.cs
+++ b/EasyReasy.Auth.Tests/RefreshTokenServiceTests.cs
@@ -271,5 +271,161 @@ namespace EasyReasy.Auth.Tests
             string? serialized = RefreshTokenService.SerializeRoles(new List<string>());
             Assert.IsNull(serialized);
         }
+
+        [TestMethod]
+        public async Task LogoutAsync_WithValidToken_ShouldInvalidateFamily()
+        {
+            string rawToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string hash = RefreshTokenService.HashToken(rawToken);
+            string familyId = _store.Tokens[hash].FamilyId;
+
+            await _service.LogoutAsync(rawToken);
+
+            Assert.IsTrue(_store.Tokens[hash].IsInvalidated);
+            Assert.AreEqual(familyId, _store.Tokens[hash].FamilyId);
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_WithNullToken_ShouldCompleteSilently()
+        {
+            await _service.LogoutAsync(null!);
+
+            Assert.AreEqual(0, _store.Tokens.Count);
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_WithEmptyToken_ShouldCompleteSilently()
+        {
+            await _service.LogoutAsync(string.Empty);
+
+            Assert.AreEqual(0, _store.Tokens.Count);
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_WithNonexistentToken_ShouldCompleteSilently()
+        {
+            await _service.LogoutAsync("nonexistent-token");
+
+            Assert.AreEqual(0, _store.Tokens.Count);
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_CalledTwice_ShouldCompleteSilently()
+        {
+            string rawToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+
+            await _service.LogoutAsync(rawToken);
+            await _service.LogoutAsync(rawToken);
+
+            string hash = RefreshTokenService.HashToken(rawToken);
+            Assert.IsTrue(_store.Tokens[hash].IsInvalidated);
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_AfterRotations_ShouldInvalidateEntireFamily()
+        {
+            string currentToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string originalHash = RefreshTokenService.HashToken(currentToken);
+            string familyId = _store.Tokens[originalHash].FamilyId;
+
+            // Rotate a couple of times
+            for (int i = 0; i < 3; i++)
+            {
+                RefreshResult result = await _service.RefreshAsync(currentToken, _jwtTokenService);
+                Assert.IsTrue(result.Success);
+                currentToken = result.NewRefreshToken!;
+            }
+
+            await _service.LogoutAsync(currentToken);
+
+            // Every token in the family should now be invalidated
+            foreach (StoredRefreshToken token in _store.Tokens.Values)
+            {
+                if (token.FamilyId == familyId)
+                {
+                    Assert.IsTrue(token.IsInvalidated);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_WithConsumedButNotInvalidatedToken_ShouldInvalidateFamily()
+        {
+            string rawToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string originalHash = RefreshTokenService.HashToken(rawToken);
+            string familyId = _store.Tokens[originalHash].FamilyId;
+
+            // Rotate once — the original token is now consumed but the family is not invalidated
+            RefreshResult refreshResult = await _service.RefreshAsync(rawToken, _jwtTokenService);
+            Assert.IsTrue(refreshResult.Success);
+            Assert.IsNotNull(_store.Tokens[originalHash].ConsumedAt);
+            Assert.IsFalse(_store.Tokens[originalHash].IsInvalidated);
+
+            // Logging out with the consumed (but not invalidated) token must invalidate the family
+            await _service.LogoutAsync(rawToken);
+
+            foreach (StoredRefreshToken token in _store.Tokens.Values)
+            {
+                if (token.FamilyId == familyId)
+                {
+                    Assert.IsTrue(token.IsInvalidated);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task LogoutAsync_OnlyAffectsTargetedFamily()
+        {
+            string userOneToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string userTwoToken = await _service.CreateRefreshTokenAsync("user-2", "user", null, null);
+
+            await _service.LogoutAsync(userOneToken);
+
+            string userTwoHash = RefreshTokenService.HashToken(userTwoToken);
+            Assert.IsFalse(_store.Tokens[userTwoHash].IsInvalidated);
+        }
+
+        [TestMethod]
+        public async Task InvalidateAllSessionsAsync_WithMultipleFamiliesForUser_ShouldInvalidateAll()
+        {
+            string userOneTokenA = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string userOneTokenB = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string userOneTokenC = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string userTwoToken = await _service.CreateRefreshTokenAsync("user-2", "user", null, null);
+
+            await _service.InvalidateAllSessionsAsync("user-1");
+
+            Assert.IsTrue(_store.Tokens[RefreshTokenService.HashToken(userOneTokenA)].IsInvalidated);
+            Assert.IsTrue(_store.Tokens[RefreshTokenService.HashToken(userOneTokenB)].IsInvalidated);
+            Assert.IsTrue(_store.Tokens[RefreshTokenService.HashToken(userOneTokenC)].IsInvalidated);
+            Assert.IsFalse(_store.Tokens[RefreshTokenService.HashToken(userTwoToken)].IsInvalidated);
+        }
+
+        [TestMethod]
+        public async Task InvalidateAllSessionsAsync_WithNoSessions_ShouldCompleteSilently()
+        {
+            await _service.InvalidateAllSessionsAsync("user-with-no-tokens");
+
+            Assert.AreEqual(0, _store.Tokens.Count);
+        }
+
+        [TestMethod]
+        public async Task InvalidateAllSessionsAsync_AfterRotations_ShouldInvalidateAllFamilyMembers()
+        {
+            string currentToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+
+            for (int i = 0; i < 3; i++)
+            {
+                RefreshResult result = await _service.RefreshAsync(currentToken, _jwtTokenService);
+                currentToken = result.NewRefreshToken!;
+            }
+
+            await _service.InvalidateAllSessionsAsync("user-1");
+
+            foreach (StoredRefreshToken token in _store.Tokens.Values)
+            {
+                Assert.IsTrue(token.IsInvalidated);
+            }
+        }
     }
 }

--- a/EasyReasy.Auth.Tests/SessionRevocationResultTests.cs
+++ b/EasyReasy.Auth.Tests/SessionRevocationResultTests.cs
@@ -1,0 +1,23 @@
+namespace EasyReasy.Auth.Tests
+{
+    [TestClass]
+    public class SessionRevocationResultTests
+    {
+        [TestMethod]
+        public void Constructor_ShouldPopulateProperties()
+        {
+            SessionRevocationResult result = new SessionRevocationResult("user-42", 3);
+
+            Assert.AreEqual("user-42", result.Subject);
+            Assert.AreEqual(3, result.InvalidatedFamilyCount);
+        }
+
+        [TestMethod]
+        public void Constructor_WithZeroCount_ShouldAllowZero()
+        {
+            SessionRevocationResult result = new SessionRevocationResult("user-42", 0);
+
+            Assert.AreEqual(0, result.InvalidatedFamilyCount);
+        }
+    }
+}

--- a/EasyReasy.Auth/ApiKeyAuthFailureReason.cs
+++ b/EasyReasy.Auth/ApiKeyAuthFailureReason.cs
@@ -1,0 +1,30 @@
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// Represents the reason an API key authentication attempt failed.
+    /// Intended to flow into audit logs (e.g. ISO 27001 A.12.4.1 records of failed authentication attempts)
+    /// — never returned to the client.
+    /// </summary>
+    public enum ApiKeyAuthFailureReason
+    {
+        /// <summary>
+        /// No API key is registered matching the supplied value.
+        /// </summary>
+        UnknownKey,
+
+        /// <summary>
+        /// The API key was previously registered but has been revoked.
+        /// </summary>
+        KeyRevoked,
+
+        /// <summary>
+        /// The API key has passed its configured expiration time.
+        /// </summary>
+        KeyExpired,
+
+        /// <summary>
+        /// The API key authentication failed for a consumer-specific reason that does not fit the other categories.
+        /// </summary>
+        Other,
+    }
+}

--- a/EasyReasy.Auth/ApiKeyAuthResult.cs
+++ b/EasyReasy.Auth/ApiKeyAuthResult.cs
@@ -1,0 +1,74 @@
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// Represents the result of an API key authentication validation.
+    /// Use the static factory methods <see cref="Succeeded"/> and <see cref="Failed"/> to create instances.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately does not carry the raw API key, so that consumer code logging the whole result
+    /// cannot accidentally leak secrets.
+    /// </remarks>
+    public sealed class ApiKeyAuthResult
+    {
+        /// <summary>
+        /// Whether the API key authentication attempt succeeded.
+        /// </summary>
+        public bool Success { get; }
+
+        /// <summary>
+        /// The authentication response containing the access token and (optionally) a refresh token.
+        /// Only populated when <see cref="Success"/> is true.
+        /// </summary>
+        public AuthResponse? AuthResponse { get; }
+
+        /// <summary>
+        /// The client identifier associated with the attempt.
+        /// Populated on success, and on failure when the client identifier is known — even if the key is unknown
+        /// (<see cref="ApiKeyAuthFailureReason.UnknownKey"/>). Intended to support ISO 27001 A.12.4.1 audit logging.
+        /// </summary>
+        public string? AttemptedClientId { get; }
+
+        /// <summary>
+        /// The reason the API key authentication attempt failed.
+        /// Only populated when <see cref="Success"/> is false.
+        /// </summary>
+        public ApiKeyAuthFailureReason? FailureReason { get; }
+
+        private ApiKeyAuthResult(
+            bool success,
+            AuthResponse? authResponse,
+            string? attemptedClientId,
+            ApiKeyAuthFailureReason? failureReason)
+        {
+            Success = success;
+            AuthResponse = authResponse;
+            AttemptedClientId = attemptedClientId;
+            FailureReason = failureReason;
+        }
+
+        /// <summary>
+        /// Creates a successful API key authentication result.
+        /// </summary>
+        /// <param name="authResponse">The authentication response containing the access token.</param>
+        /// <param name="clientId">The client identifier that was authenticated.</param>
+        /// <returns>A successful <see cref="ApiKeyAuthResult"/>.</returns>
+        public static ApiKeyAuthResult Succeeded(AuthResponse authResponse, string clientId)
+        {
+            return new ApiKeyAuthResult(true, authResponse, clientId, null);
+        }
+
+        /// <summary>
+        /// Creates a failed API key authentication result.
+        /// </summary>
+        /// <param name="reason">The reason the API key authentication attempt failed.</param>
+        /// <param name="attemptedClientId">
+        /// The client identifier that was attempted, when available. May be <c>null</c> if the request did not
+        /// include one. Populate whenever possible so audit logs can attribute the failure.
+        /// </param>
+        /// <returns>A failed <see cref="ApiKeyAuthResult"/>.</returns>
+        public static ApiKeyAuthResult Failed(ApiKeyAuthFailureReason reason, string? attemptedClientId = null)
+        {
+            return new ApiKeyAuthResult(false, null, attemptedClientId, reason);
+        }
+    }
+}

--- a/EasyReasy.Auth/AuthApplicationBuilderExtensions.cs
+++ b/EasyReasy.Auth/AuthApplicationBuilderExtensions.cs
@@ -12,6 +12,21 @@ namespace EasyReasy.Auth
         private const string NoCacheHeaderValue = "no-store";
 
         /// <summary>
+        /// Resolves <see cref="IAuthAuditLogger"/> from the request scope (if registered) and invokes the supplied hook.
+        /// No-op when no logger is registered. Used by the endpoint-driven hooks (<see cref="IAuthAuditLogger.OnLoginAsync"/>
+        /// and <see cref="IAuthAuditLogger.OnApiKeyAuthAsync"/>); the service-driven hooks (<c>OnRefreshAsync</c>,
+        /// <c>OnLogoutAsync</c>, <c>OnSessionsInvalidatedAsync</c>) are invoked from inside <see cref="RefreshTokenService"/>.
+        /// </summary>
+        private static async Task InvokeAuditHookAsync(HttpContext httpContext, Func<IAuthAuditLogger, HttpContext, Task> hook)
+        {
+            IAuthAuditLogger? auditLogger = httpContext.RequestServices.GetService<IAuthAuditLogger>();
+            if (auditLogger != null)
+            {
+                await hook(auditLogger, httpContext);
+            }
+        }
+
+        /// <summary>
         /// Adds authentication, authorization, claims injection, and progressive delay middleware
         /// to the application pipeline using default options.
         /// </summary>
@@ -53,6 +68,9 @@ namespace EasyReasy.Auth
         /// </summary>
         /// <remarks>
         /// Requires <see cref="IAuthRequestValidationService"/> to be registered in DI.
+        /// If <see cref="IAuthAuditLogger"/> is registered, <see cref="IAuthAuditLogger.OnApiKeyAuthAsync"/>
+        /// is invoked after validation (for both success and failure) before the response is written.
+        /// An exception thrown by the audit logger will propagate out of the endpoint as a 500.
         /// </remarks>
         /// <param name="app">The web application.</param>
         /// <returns>The web application for chaining.</returns>
@@ -61,8 +79,13 @@ namespace EasyReasy.Auth
             app.MapPost("/api/auth/apikey", async (ApiKeyAuthRequest request, IAuthRequestValidationService validationService, IJwtTokenService jwtTokenService, HttpContext httpContext) =>
             {
                 httpContext.Response.Headers["Cache-Control"] = NoCacheHeaderValue;
-                AuthResponse? response = await validationService.ValidateApiKeyRequestAsync(request, jwtTokenService, httpContext);
-                return response != null ? Results.Ok(response) : Results.Unauthorized();
+                ApiKeyAuthResult result = await validationService.ValidateApiKeyRequestAsync(request, jwtTokenService, httpContext);
+
+                await InvokeAuditHookAsync(httpContext, (logger, ctx) => logger.OnApiKeyAuthAsync(ctx, result));
+
+                return result.Success && result.AuthResponse != null
+                    ? Results.Ok(result.AuthResponse)
+                    : Results.Unauthorized();
             }).AllowAnonymous();
 
             return app;
@@ -73,6 +96,9 @@ namespace EasyReasy.Auth
         /// </summary>
         /// <remarks>
         /// Requires <see cref="IAuthRequestValidationService"/> to be registered in DI.
+        /// If <see cref="IAuthAuditLogger"/> is registered, <see cref="IAuthAuditLogger.OnLoginAsync"/>
+        /// is invoked after validation (for both success and failure) before the response is written.
+        /// An exception thrown by the audit logger will propagate out of the endpoint as a 500.
         /// </remarks>
         /// <param name="app">The web application.</param>
         /// <returns>The web application for chaining.</returns>
@@ -81,8 +107,13 @@ namespace EasyReasy.Auth
             app.MapPost("/api/auth/login", async (LoginAuthRequest request, IAuthRequestValidationService validationService, IJwtTokenService jwtTokenService, HttpContext httpContext) =>
             {
                 httpContext.Response.Headers["Cache-Control"] = NoCacheHeaderValue;
-                AuthResponse? response = await validationService.ValidateLoginRequestAsync(request, jwtTokenService, httpContext);
-                return response != null ? Results.Ok(response) : Results.Unauthorized();
+                LoginResult result = await validationService.ValidateLoginRequestAsync(request, jwtTokenService, httpContext);
+
+                await InvokeAuditHookAsync(httpContext, (logger, ctx) => logger.OnLoginAsync(ctx, result));
+
+                return result.Success && result.AuthResponse != null
+                    ? Results.Ok(result.AuthResponse)
+                    : Results.Unauthorized();
             }).AllowAnonymous();
 
             return app;
@@ -91,6 +122,10 @@ namespace EasyReasy.Auth
         /// <summary>
         /// Adds a refresh token endpoint to the application.
         /// Requires <see cref="IRefreshTokenService"/> and <see cref="IJwtTokenService"/> to be registered in DI.
+        /// If <see cref="IAuthAuditLogger"/> is registered, its <see cref="IAuthAuditLogger.OnRefreshAsync"/>
+        /// hook is invoked by <see cref="IRefreshTokenService.RefreshAsync"/> after the refresh attempt
+        /// (for both success and failure) before the response is written.
+        /// An exception thrown by the audit logger will propagate out of the endpoint as a 500.
         /// </summary>
         /// <param name="app">The web application.</param>
         /// <returns>The web application for chaining.</returns>
@@ -99,7 +134,7 @@ namespace EasyReasy.Auth
             app.MapPost("/api/auth/refresh", async (RefreshRequest request, IRefreshTokenService refreshTokenService, IJwtTokenService jwtTokenService, HttpContext httpContext) =>
             {
                 httpContext.Response.Headers["Cache-Control"] = NoCacheHeaderValue;
-                RefreshResult result = await refreshTokenService.RefreshAsync(request.RefreshToken, jwtTokenService, httpContext.RequestAborted);
+                RefreshResult result = await refreshTokenService.RefreshAsync(request.RefreshToken, jwtTokenService, httpContext, httpContext.RequestAborted);
 
                 if (result.Success)
                 {
@@ -120,6 +155,10 @@ namespace EasyReasy.Auth
         /// The endpoint is anonymous (no access token required), accepts a <see cref="LogoutRequest"/> body,
         /// and always returns 204 No Content — even when the token is unknown, null, or already invalidated —
         /// so that the response body does not reveal whether the supplied token was known.
+        /// If <see cref="IAuthAuditLogger"/> is registered, its <see cref="IAuthAuditLogger.OnLogoutAsync"/>
+        /// hook is invoked by <see cref="IRefreshTokenService.LogoutAsync"/> before the response is written,
+        /// so consumers can record which family was invalidated even though the wire response carries no body.
+        /// An exception thrown by the audit logger will propagate out of the endpoint as a 500.
         /// </remarks>
         /// <param name="app">The web application.</param>
         /// <returns>The web application for chaining.</returns>
@@ -128,7 +167,7 @@ namespace EasyReasy.Auth
             app.MapPost("/api/auth/logout", async (LogoutRequest request, IRefreshTokenService refreshTokenService, HttpContext httpContext) =>
             {
                 httpContext.Response.Headers["Cache-Control"] = NoCacheHeaderValue;
-                await refreshTokenService.LogoutAsync(request.RefreshToken, httpContext.RequestAborted);
+                await refreshTokenService.LogoutAsync(request.RefreshToken, httpContext, httpContext.RequestAborted);
                 return Results.NoContent();
             }).AllowAnonymous();
 
@@ -157,13 +196,18 @@ namespace EasyReasy.Auth
             // Fail fast at startup if the required services are not registered
             using (IServiceScope scope = app.Services.CreateScope())
             {
-                IAuthRequestValidationService? validationService = scope.ServiceProvider.GetService<IAuthRequestValidationService>();
-                if (validationService == null)
+                if (allowApiKeys || allowUsernamePassword)
                 {
-                    throw new InvalidOperationException(
-                        $"{nameof(IAuthRequestValidationService)} is not registered in the DI container. " +
-                        $"Register it before calling {nameof(AddAuthEndpoints)}, e.g.: " +
-                        $"builder.Services.AddScoped<{nameof(IAuthRequestValidationService)}, MyAuthService>();");
+                    IAuthRequestValidationService? validationService = scope.ServiceProvider.GetService<IAuthRequestValidationService>();
+                    if (validationService == null)
+                    {
+                        throw new InvalidOperationException(
+                            $"{nameof(IAuthRequestValidationService)} is not registered in the DI container, " +
+                            $"but API key or username/password authentication is enabled. " +
+                            $"Register it before calling {nameof(AddAuthEndpoints)}, e.g.: " +
+                            $"builder.Services.AddScoped<{nameof(IAuthRequestValidationService)}, MyAuthService>(); " +
+                            $"or disable with allowApiKeys: false and allowUsernamePassword: false.");
+                    }
                 }
 
                 if (allowRefresh || allowLogout)

--- a/EasyReasy.Auth/AuthApplicationBuilderExtensions.cs
+++ b/EasyReasy.Auth/AuthApplicationBuilderExtensions.cs
@@ -63,7 +63,7 @@ namespace EasyReasy.Auth
                 httpContext.Response.Headers["Cache-Control"] = NoCacheHeaderValue;
                 AuthResponse? response = await validationService.ValidateApiKeyRequestAsync(request, jwtTokenService, httpContext);
                 return response != null ? Results.Ok(response) : Results.Unauthorized();
-            });
+            }).AllowAnonymous();
 
             return app;
         }
@@ -83,7 +83,7 @@ namespace EasyReasy.Auth
                 httpContext.Response.Headers["Cache-Control"] = NoCacheHeaderValue;
                 AuthResponse? response = await validationService.ValidateLoginRequestAsync(request, jwtTokenService, httpContext);
                 return response != null ? Results.Ok(response) : Results.Unauthorized();
-            });
+            }).AllowAnonymous();
 
             return app;
         }
@@ -99,7 +99,7 @@ namespace EasyReasy.Auth
             app.MapPost("/api/auth/refresh", async (RefreshRequest request, IRefreshTokenService refreshTokenService, IJwtTokenService jwtTokenService, HttpContext httpContext) =>
             {
                 httpContext.Response.Headers["Cache-Control"] = NoCacheHeaderValue;
-                RefreshResult result = await refreshTokenService.RefreshAsync(request.RefreshToken, jwtTokenService);
+                RefreshResult result = await refreshTokenService.RefreshAsync(request.RefreshToken, jwtTokenService, httpContext.RequestAborted);
 
                 if (result.Success)
                 {
@@ -107,7 +107,30 @@ namespace EasyReasy.Auth
                 }
 
                 return Results.Unauthorized();
-            });
+            }).AllowAnonymous();
+
+            return app;
+        }
+
+        /// <summary>
+        /// Adds a logout endpoint that revokes the refresh token family for the supplied token.
+        /// Requires <see cref="IRefreshTokenService"/> to be registered in DI.
+        /// </summary>
+        /// <remarks>
+        /// The endpoint is anonymous (no access token required), accepts a <see cref="LogoutRequest"/> body,
+        /// and always returns 204 No Content — even when the token is unknown, null, or already invalidated —
+        /// so that the response body does not reveal whether the supplied token was known.
+        /// </remarks>
+        /// <param name="app">The web application.</param>
+        /// <returns>The web application for chaining.</returns>
+        public static WebApplication AddLogoutEndpoint(this WebApplication app)
+        {
+            app.MapPost("/api/auth/logout", async (LogoutRequest request, IRefreshTokenService refreshTokenService, HttpContext httpContext) =>
+            {
+                httpContext.Response.Headers["Cache-Control"] = NoCacheHeaderValue;
+                await refreshTokenService.LogoutAsync(request.RefreshToken, httpContext.RequestAborted);
+                return Results.NoContent();
+            }).AllowAnonymous();
 
             return app;
         }
@@ -121,15 +144,17 @@ namespace EasyReasy.Auth
         /// <param name="app">The web application.</param>
         /// <param name="allowApiKeys">Whether to enable API key authentication. Default is true.</param>
         /// <param name="allowUsernamePassword">Whether to enable username/password authentication. Default is true.</param>
-        /// <param name="allowRefresh">Whether to enable the refresh token endpoint. Default is false.</param>
+        /// <param name="allowRefresh">Whether to enable the refresh token endpoint. Default is false (opt-in because refresh changes how access tokens are issued).</param>
+        /// <param name="allowLogout">Whether to enable the logout endpoint. Default is true (safe to expose because logout is a no-op for unknown tokens and gives consumers the full logout story out of the box).</param>
         /// <returns>The web application for chaining.</returns>
         public static WebApplication AddAuthEndpoints(
             this WebApplication app,
             bool allowApiKeys = true,
             bool allowUsernamePassword = true,
-            bool allowRefresh = false)
+            bool allowRefresh = false,
+            bool allowLogout = true)
         {
-            // Fail fast at startup if the required service is not registered
+            // Fail fast at startup if the required services are not registered
             using (IServiceScope scope = app.Services.CreateScope())
             {
                 IAuthRequestValidationService? validationService = scope.ServiceProvider.GetService<IAuthRequestValidationService>();
@@ -139,6 +164,20 @@ namespace EasyReasy.Auth
                         $"{nameof(IAuthRequestValidationService)} is not registered in the DI container. " +
                         $"Register it before calling {nameof(AddAuthEndpoints)}, e.g.: " +
                         $"builder.Services.AddScoped<{nameof(IAuthRequestValidationService)}, MyAuthService>();");
+                }
+
+                if (allowRefresh || allowLogout)
+                {
+                    IRefreshTokenService? refreshTokenService = scope.ServiceProvider.GetService<IRefreshTokenService>();
+                    if (refreshTokenService == null)
+                    {
+                        throw new InvalidOperationException(
+                            $"{nameof(IRefreshTokenService)} is not registered in the DI container, " +
+                            $"but the refresh or logout endpoint is enabled. " +
+                            $"Register it before calling {nameof(AddAuthEndpoints)}, e.g.: " +
+                            $"builder.Services.AddRefreshTokenService<MyRefreshTokenStore>(); " +
+                            $"or disable the endpoints with allowRefresh: false and allowLogout: false.");
+                    }
                 }
             }
 
@@ -155,6 +194,11 @@ namespace EasyReasy.Auth
             if (allowRefresh)
             {
                 app.AddRefreshEndpoint();
+            }
+
+            if (allowLogout)
+            {
+                app.AddLogoutEndpoint();
             }
 
             return app;

--- a/EasyReasy.Auth/AuthServiceCollectionExtensions.cs
+++ b/EasyReasy.Auth/AuthServiceCollectionExtensions.cs
@@ -118,7 +118,8 @@ namespace EasyReasy.Auth
             services.AddScoped<IRefreshTokenService>(provider =>
             {
                 IRefreshTokenStore store = provider.GetRequiredService<IRefreshTokenStore>();
-                return new RefreshTokenService(store, refreshTokenLifetime, accessTokenLifetime);
+                IAuthAuditLogger? auditLogger = provider.GetService<IAuthAuditLogger>();
+                return new RefreshTokenService(store, refreshTokenLifetime, accessTokenLifetime, auditLogger);
             });
 
             return services;

--- a/EasyReasy.Auth/EasyReasy.Auth.csproj
+++ b/EasyReasy.Auth/EasyReasy.Auth.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>4.0.0</VersionPrefix>
     <PackageIcon>BaseIcon.png</PackageIcon>
   </PropertyGroup>
 

--- a/EasyReasy.Auth/IAuthAuditLogger.cs
+++ b/EasyReasy.Auth/IAuthAuditLogger.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Http;
+
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// Optional service that receives structured notifications for every authentication event
+    /// the library surfaces. Register an implementation in DI to emit ISO 27001 A.12.4.1 audit
+    /// records (successful authentications, failed authentications, session termination, and
+    /// bulk session revocation).
+    /// </summary>
+    /// <remarks>
+    /// <para>All methods have default no-op implementations — implement only the events you care about.</para>
+    /// <para>Hooks are invoked after the operation completes and before the response is written,
+    /// in the request scope (when triggered from an HTTP endpoint), so implementations may freely access request-scoped services.</para>
+    /// <para>Implementations must not throw. Exceptions from an audit logger will propagate out of the caller
+    /// and turn an otherwise-successful auth operation into a 500 (when triggered from an HTTP endpoint).</para>
+    /// <para>None of the result types carry a raw password or a raw API key, so failure records are safe to serialise.
+    /// On the success path, however, <see cref="LoginResult"/> and <see cref="ApiKeyAuthResult"/> embed an
+    /// <see cref="AuthResponse"/> that carries the issued JWT and (when refresh tokens are enabled) the raw refresh token —
+    /// both are bearer credentials. Implementations should log metadata (<c>Success</c>, attempted-subject, failure reason, IP)
+    /// rather than the whole result; in particular, never pass a result to a structured logger's destructuring syntax
+    /// (e.g. Serilog <c>{@result}</c>) or to <c>JsonSerializer.Serialize</c>, because that would write the access token
+    /// and refresh token to log storage.</para>
+    /// <para>
+    /// <b>Register as singleton or scoped.</b> <see cref="RefreshTokenService"/> captures the logger at construction
+    /// time, so the logger must outlive the service that captured it. The library registers <see cref="IRefreshTokenService"/>
+    /// as scoped, which means a scoped or singleton logger works correctly. Transient is wasteful but harmless. Avoid any
+    /// lifetime shorter than <see cref="IRefreshTokenService"/>'s — the only realistic way to trip this is to re-register
+    /// <see cref="IRefreshTokenService"/> as singleton while keeping a scoped logger, which would cause the service to cache
+    /// one scope's logger for its entire lifetime.
+    /// </para>
+    /// <para>
+    /// <b>Hook placement</b>:
+    /// <see cref="OnRefreshAsync"/>, <see cref="OnLogoutAsync"/>, and <see cref="OnSessionsInvalidatedAsync"/> are invoked
+    /// from inside <see cref="RefreshTokenService"/>, so both HTTP-endpoint and programmatic callers trigger the hook.
+    /// <see cref="OnLoginAsync"/> and <see cref="OnApiKeyAuthAsync"/> are invoked from the HTTP endpoint layer only, because
+    /// the underlying <see cref="IAuthRequestValidationService"/> is consumer-implemented and cannot be guaranteed to call
+    /// the audit logger itself. Consumers who validate credentials outside the HTTP endpoint flow can resolve
+    /// <see cref="IAuthAuditLogger"/> from DI and invoke <see cref="OnLoginAsync"/> / <see cref="OnApiKeyAuthAsync"/>
+    /// themselves — the library's endpoint code uses the interface exactly the same way.
+    /// </para>
+    /// <para>
+    /// <b>Default-interface-method caveat</b>: the no-op defaults only resolve when a method is invoked through the
+    /// <see cref="IAuthAuditLogger"/> interface. Calling an unimplemented method directly on the concrete class (e.g.
+    /// <c>new MyLogger().OnLoginAsync(...)</c>) will fail to compile because the class does not provide an implementation.
+    /// Always pass an instance as <see cref="IAuthAuditLogger"/>, or have the class implement every method explicitly if
+    /// you need to invoke them on the concrete type.
+    /// </para>
+    /// </remarks>
+    public interface IAuthAuditLogger
+    {
+        /// <summary>
+        /// Invoked after a username/password login attempt. <paramref name="result"/> carries
+        /// success state, the attempted subject, and (on failure) a <see cref="LoginFailureReason"/>.
+        /// </summary>
+        /// <param name="httpContext">The HTTP context of the request that triggered the event.</param>
+        /// <param name="result">The structured result of the login validation.</param>
+        Task OnLoginAsync(HttpContext httpContext, LoginResult result) => Task.CompletedTask;
+
+        /// <summary>
+        /// Invoked after an API key authentication attempt. <paramref name="result"/> carries
+        /// success state, the attempted client identifier, and (on failure) an <see cref="ApiKeyAuthFailureReason"/>.
+        /// </summary>
+        /// <param name="httpContext">The HTTP context of the request that triggered the event.</param>
+        /// <param name="result">The structured result of the API key validation.</param>
+        Task OnApiKeyAuthAsync(HttpContext httpContext, ApiKeyAuthResult result) => Task.CompletedTask;
+
+        /// <summary>
+        /// Invoked after a refresh token operation. <paramref name="result"/> carries success state,
+        /// the subject and family identifier (when known), and (on failure) a <see cref="RefreshFailureReason"/>.
+        /// A <see cref="RefreshFailureReason.TheftDetected"/> result is particularly security-relevant.
+        /// </summary>
+        /// <param name="httpContext">
+        /// The HTTP context of the request that triggered the event, or <c>null</c> when the refresh was
+        /// invoked programmatically (e.g. from a background service). Implementations should guard against null
+        /// when recording IP or User-Agent data.
+        /// </param>
+        /// <param name="result">The structured result of the refresh operation.</param>
+        Task OnRefreshAsync(HttpContext? httpContext, RefreshResult result) => Task.CompletedTask;
+
+        /// <summary>
+        /// Invoked after a logout operation. <paramref name="result"/> reports whether the supplied
+        /// token matched a stored family and, if so, the subject and family identifier that were invalidated.
+        /// </summary>
+        /// <param name="httpContext">
+        /// The HTTP context of the request that triggered the event, or <c>null</c> when the logout was
+        /// invoked programmatically (e.g. from a background service). Implementations should guard against null
+        /// when recording IP or User-Agent data.
+        /// </param>
+        /// <param name="result">The structured result of the logout operation.</param>
+        Task OnLogoutAsync(HttpContext? httpContext, LogoutResult result) => Task.CompletedTask;
+
+        /// <summary>
+        /// Invoked after a bulk session revocation (programmatic call to
+        /// <see cref="IRefreshTokenService.InvalidateAllSessionsAsync"/>). Not tied to an HTTP request —
+        /// consumers should log timestamp and any caller-side context (e.g. admin identity) themselves.
+        /// </summary>
+        /// <param name="result">The structured result of the bulk revocation.</param>
+        Task OnSessionsInvalidatedAsync(SessionRevocationResult result) => Task.CompletedTask;
+    }
+}

--- a/EasyReasy.Auth/IAuthRequestValidationService.cs
+++ b/EasyReasy.Auth/IAuthRequestValidationService.cs
@@ -5,24 +5,34 @@ namespace EasyReasy.Auth
     /// <summary>
     /// Service for validating authentication requests and creating JWT tokens.
     /// </summary>
+    /// <remarks>
+    /// Implementations must populate the <c>AttemptedSubject</c> / <c>AttemptedClientId</c> property on the returned
+    /// result whenever it is knowable — including on failure for <see cref="LoginFailureReason.UnknownUser"/>
+    /// or <see cref="ApiKeyAuthFailureReason.UnknownKey"/> — so that consumers can emit ISO 27001 A.12.4.1
+    /// compliant audit records that attribute failed authentication attempts to an identifier.
+    /// </remarks>
     public interface IAuthRequestValidationService
     {
         /// <summary>
-        /// Validates an API key authentication request and returns a JWT token if valid.
+        /// Validates an API key authentication request.
         /// </summary>
         /// <param name="request">The API key authentication request.</param>
         /// <param name="jwtTokenService">The JWT token service for creating tokens.</param>
-        /// <param name="httpContext">The HTTP context containing request information like headers and query parameters. Can be null for backward compatibility.</param>
-        /// <returns>An AuthResponse with the JWT token if valid, null if invalid.</returns>
-        Task<AuthResponse?> ValidateApiKeyRequestAsync(ApiKeyAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null);
+        /// <param name="httpContext">The HTTP context containing request information like headers and query parameters. Can be null for non-HTTP validation flows.</param>
+        /// <returns>
+        /// An <see cref="ApiKeyAuthResult"/> describing success or failure. The result never carries the raw API key.
+        /// </returns>
+        Task<ApiKeyAuthResult> ValidateApiKeyRequestAsync(ApiKeyAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null);
 
         /// <summary>
-        /// Validates a username/password authentication request and returns a JWT token if valid.
+        /// Validates a username/password authentication request.
         /// </summary>
         /// <param name="request">The username/password authentication request.</param>
         /// <param name="jwtTokenService">The JWT token service for creating tokens.</param>
-        /// <param name="httpContext">The HTTP context containing request information like headers and query parameters. Can be null for backward compatibility.</param>
-        /// <returns>An AuthResponse with the JWT token if valid, null if invalid.</returns>
-        Task<AuthResponse?> ValidateLoginRequestAsync(LoginAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null);
+        /// <param name="httpContext">The HTTP context containing request information like headers and query parameters. Can be null for non-HTTP validation flows.</param>
+        /// <returns>
+        /// A <see cref="LoginResult"/> describing success or failure. The result never carries the raw password.
+        /// </returns>
+        Task<LoginResult> ValidateLoginRequestAsync(LoginAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null);
     }
 }

--- a/EasyReasy.Auth/IRefreshTokenService.cs
+++ b/EasyReasy.Auth/IRefreshTokenService.cs
@@ -14,8 +14,9 @@ namespace EasyReasy.Auth
         /// <param name="authType">The authentication type (e.g., "apikey" or "user").</param>
         /// <param name="serializedClaims">JSON-serialized additional claims, or null if none.</param>
         /// <param name="serializedRoles">JSON-serialized roles, or null if none.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>The raw refresh token string to return to the client.</returns>
-        Task<string> CreateRefreshTokenAsync(string subject, string authType, string? serializedClaims, string? serializedRoles);
+        Task<string> CreateRefreshTokenAsync(string subject, string authType, string? serializedClaims, string? serializedRoles, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Validates a refresh token and issues a new access token and refresh token pair.
@@ -24,7 +25,25 @@ namespace EasyReasy.Auth
         /// </summary>
         /// <param name="refreshToken">The raw refresh token from the client.</param>
         /// <param name="jwtTokenService">The JWT token service used to create the new access token.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A <see cref="RefreshResult"/> indicating success or failure.</returns>
-        Task<RefreshResult> RefreshAsync(string refreshToken, IJwtTokenService jwtTokenService);
+        Task<RefreshResult> RefreshAsync(string refreshToken, IJwtTokenService jwtTokenService, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Revokes the refresh token family that the supplied token belongs to.
+        /// The operation is idempotent — unknown, already-consumed, or already-invalidated
+        /// tokens complete silently without throwing, so callers do not leak which tokens exist.
+        /// </summary>
+        /// <param name="refreshToken">The raw refresh token to log out.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
+        Task LogoutAsync(string refreshToken, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Invalidates every refresh token family for the specified subject.
+        /// Intended for password change, role demotion, and admin-forced logout flows.
+        /// </summary>
+        /// <param name="subject">The subject (user identifier) whose sessions should be revoked.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
+        Task InvalidateAllSessionsAsync(string subject, CancellationToken cancellationToken = default);
     }
 }

--- a/EasyReasy.Auth/IRefreshTokenService.cs
+++ b/EasyReasy.Auth/IRefreshTokenService.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Http;
+
 namespace EasyReasy.Auth
 {
     /// <summary>
@@ -25,18 +27,38 @@ namespace EasyReasy.Auth
         /// </summary>
         /// <param name="refreshToken">The raw refresh token from the client.</param>
         /// <param name="jwtTokenService">The JWT token service used to create the new access token.</param>
+        /// <param name="httpContext">
+        /// The HTTP context of the triggering request, when called from an HTTP endpoint.
+        /// Pass <c>null</c> for programmatic refreshes (e.g. from a background service). Only used to
+        /// propagate context to <see cref="IAuthAuditLogger.OnRefreshAsync"/>.
+        /// </param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A <see cref="RefreshResult"/> indicating success or failure.</returns>
-        Task<RefreshResult> RefreshAsync(string refreshToken, IJwtTokenService jwtTokenService, CancellationToken cancellationToken = default);
+        Task<RefreshResult> RefreshAsync(string refreshToken, IJwtTokenService jwtTokenService, HttpContext? httpContext = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Revokes the refresh token family that the supplied token belongs to.
         /// The operation is idempotent — unknown, already-consumed, or already-invalidated
         /// tokens complete silently without throwing, so callers do not leak which tokens exist.
+        /// Null or empty tokens are accepted and treated as a no-op for the same reason.
         /// </summary>
-        /// <param name="refreshToken">The raw refresh token to log out.</param>
+        /// <param name="refreshToken">
+        /// The raw refresh token to log out. May be <c>null</c> or empty — treated as a no-op in either case
+        /// so the HTTP endpoint can respond 204 regardless of input.
+        /// </param>
+        /// <param name="httpContext">
+        /// The HTTP context of the triggering request, when called from an HTTP endpoint.
+        /// Pass <c>null</c> for programmatic logouts (e.g. from a background service). Only used to
+        /// propagate context to <see cref="IAuthAuditLogger.OnLogoutAsync"/>.
+        /// </param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
-        Task LogoutAsync(string refreshToken, CancellationToken cancellationToken = default);
+        /// <returns>
+        /// A <see cref="LogoutResult"/> describing whether the token matched a stored family and,
+        /// if so, the subject and family identifier that were invalidated. The built-in endpoint
+        /// does not return this to the client (it always responds 204), but it is surfaced here
+        /// so consumers can drive audit logging.
+        /// </returns>
+        Task<LogoutResult> LogoutAsync(string? refreshToken, HttpContext? httpContext = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Invalidates every refresh token family for the specified subject.
@@ -44,6 +66,11 @@ namespace EasyReasy.Auth
         /// </summary>
         /// <param name="subject">The subject (user identifier) whose sessions should be revoked.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
-        Task InvalidateAllSessionsAsync(string subject, CancellationToken cancellationToken = default);
+        /// <returns>
+        /// A <see cref="SessionRevocationResult"/> containing the subject and the number of
+        /// refresh token families that were invalidated. A count of zero means the subject had
+        /// no active sessions at the time of the call.
+        /// </returns>
+        Task<SessionRevocationResult> InvalidateAllSessionsAsync(string subject, CancellationToken cancellationToken = default);
     }
 }

--- a/EasyReasy.Auth/IRefreshTokenStore.cs
+++ b/EasyReasy.Auth/IRefreshTokenStore.cs
@@ -49,6 +49,11 @@ namespace EasyReasy.Auth
         /// </summary>
         /// <param name="subject">The subject (user identifier) whose sessions should be revoked.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
-        Task InvalidateAllFamiliesForUserAsync(string subject, CancellationToken cancellationToken = default);
+        /// <returns>
+        /// The number of token families that were invalidated by the operation. Implementations should
+        /// count distinct families (not individual tokens) so that the value reflects the number of
+        /// real sessions terminated — this flows into audit logs via <see cref="SessionRevocationResult"/>.
+        /// </returns>
+        Task<int> InvalidateAllFamiliesForUserAsync(string subject, CancellationToken cancellationToken = default);
     }
 }

--- a/EasyReasy.Auth/IRefreshTokenStore.cs
+++ b/EasyReasy.Auth/IRefreshTokenStore.cs
@@ -11,14 +11,16 @@ namespace EasyReasy.Auth
         /// Stores a new refresh token.
         /// </summary>
         /// <param name="refreshToken">The refresh token to store.</param>
-        Task StoreAsync(StoredRefreshToken refreshToken);
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
+        Task StoreAsync(StoredRefreshToken refreshToken, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves a stored refresh token by its hash.
         /// </summary>
         /// <param name="tokenHash">The SHA-256 hash of the raw refresh token.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>The stored refresh token, or null if not found.</returns>
-        Task<StoredRefreshToken?> GetByTokenHashAsync(string tokenHash);
+        Task<StoredRefreshToken?> GetByTokenHashAsync(string tokenHash, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Atomically marks a refresh token as consumed (used to obtain a new token pair).
@@ -28,14 +30,25 @@ namespace EasyReasy.Auth
         /// </summary>
         /// <param name="tokenHash">The SHA-256 hash of the consumed refresh token.</param>
         /// <param name="consumedAt">The UTC time when the token was consumed.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>True if the token was successfully marked as consumed; false if it was already consumed by another request.</returns>
-        Task<bool> MarkAsConsumedAsync(string tokenHash, DateTime consumedAt);
+        Task<bool> MarkAsConsumedAsync(string tokenHash, DateTime consumedAt, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Invalidates all refresh tokens in a token family.
-        /// Called when token theft is detected (a consumed token is reused).
+        /// Called when token theft is detected (a consumed token is reused) or when a user logs out.
         /// </summary>
         /// <param name="familyId">The family identifier of the token chain to invalidate.</param>
-        Task InvalidateFamilyAsync(string familyId);
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
+        Task InvalidateFamilyAsync(string familyId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Invalidates every non-invalidated refresh token family for the specified subject.
+        /// Used for bulk session revocation scenarios such as password change, role demotion,
+        /// or admin-forced logout.
+        /// </summary>
+        /// <param name="subject">The subject (user identifier) whose sessions should be revoked.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
+        Task InvalidateAllFamiliesForUserAsync(string subject, CancellationToken cancellationToken = default);
     }
 }

--- a/EasyReasy.Auth/LoginFailureReason.cs
+++ b/EasyReasy.Auth/LoginFailureReason.cs
@@ -1,0 +1,35 @@
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// Represents the reason a username/password login attempt failed.
+    /// Intended to flow into audit logs (e.g. ISO 27001 A.12.4.1 records of failed authentication attempts)
+    /// — never returned to the client.
+    /// </summary>
+    public enum LoginFailureReason
+    {
+        /// <summary>
+        /// No user exists with the supplied identifier.
+        /// </summary>
+        UnknownUser,
+
+        /// <summary>
+        /// The user exists but the supplied credentials did not validate.
+        /// </summary>
+        InvalidCredentials,
+
+        /// <summary>
+        /// The user exists but is disabled (administratively deactivated).
+        /// </summary>
+        UserDisabled,
+
+        /// <summary>
+        /// The user exists but is temporarily locked (e.g. repeated failed attempts).
+        /// </summary>
+        UserLocked,
+
+        /// <summary>
+        /// The login failed for a consumer-specific reason that does not fit the other categories.
+        /// </summary>
+        Other,
+    }
+}

--- a/EasyReasy.Auth/LoginResult.cs
+++ b/EasyReasy.Auth/LoginResult.cs
@@ -1,0 +1,74 @@
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// Represents the result of a username/password login validation.
+    /// Use the static factory methods <see cref="Succeeded"/> and <see cref="Failed"/> to create instances.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately does not carry the raw password or any other credential, so that consumer code
+    /// logging the whole result cannot accidentally leak secrets.
+    /// </remarks>
+    public sealed class LoginResult
+    {
+        /// <summary>
+        /// Whether the login attempt succeeded.
+        /// </summary>
+        public bool Success { get; }
+
+        /// <summary>
+        /// The authentication response containing the access token and (optionally) a refresh token.
+        /// Only populated when <see cref="Success"/> is true.
+        /// </summary>
+        public AuthResponse? AuthResponse { get; }
+
+        /// <summary>
+        /// The subject identifier (user id or username) associated with the attempt.
+        /// Populated on success, and on failure when the attempted identifier is known — even if the user does not exist
+        /// (<see cref="LoginFailureReason.UnknownUser"/>). Intended to support ISO 27001 A.12.4.1 audit logging.
+        /// </summary>
+        public string? AttemptedSubject { get; }
+
+        /// <summary>
+        /// The reason the login attempt failed.
+        /// Only populated when <see cref="Success"/> is false.
+        /// </summary>
+        public LoginFailureReason? FailureReason { get; }
+
+        private LoginResult(
+            bool success,
+            AuthResponse? authResponse,
+            string? attemptedSubject,
+            LoginFailureReason? failureReason)
+        {
+            Success = success;
+            AuthResponse = authResponse;
+            AttemptedSubject = attemptedSubject;
+            FailureReason = failureReason;
+        }
+
+        /// <summary>
+        /// Creates a successful login result.
+        /// </summary>
+        /// <param name="authResponse">The authentication response containing the access token.</param>
+        /// <param name="subject">The subject identifier (user id) that was authenticated.</param>
+        /// <returns>A successful <see cref="LoginResult"/>.</returns>
+        public static LoginResult Succeeded(AuthResponse authResponse, string subject)
+        {
+            return new LoginResult(true, authResponse, subject, null);
+        }
+
+        /// <summary>
+        /// Creates a failed login result.
+        /// </summary>
+        /// <param name="reason">The reason the login attempt failed.</param>
+        /// <param name="attemptedSubject">
+        /// The subject identifier that was attempted, when available. May be <c>null</c> if the request did not
+        /// carry a parseable identifier. Populate whenever possible so audit logs can attribute the failure.
+        /// </param>
+        /// <returns>A failed <see cref="LoginResult"/>.</returns>
+        public static LoginResult Failed(LoginFailureReason reason, string? attemptedSubject = null)
+        {
+            return new LoginResult(false, null, attemptedSubject, reason);
+        }
+    }
+}

--- a/EasyReasy.Auth/LogoutRequest.cs
+++ b/EasyReasy.Auth/LogoutRequest.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// Request model for logging out by revoking a refresh token family.
+    /// </summary>
+    public class LogoutRequest
+    {
+        /// <summary>
+        /// Gets the refresh token whose family should be invalidated.
+        /// </summary>
+        public string RefreshToken { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LogoutRequest"/> class.
+        /// </summary>
+        /// <param name="refreshToken">The refresh token to log out.</param>
+        public LogoutRequest(string refreshToken)
+        {
+            RefreshToken = refreshToken;
+        }
+
+        /// <summary>
+        /// Serializes this <see cref="LogoutRequest"/> instance to a JSON string.
+        /// </summary>
+        /// <returns>A JSON string representation of this <see cref="LogoutRequest"/> instance.</returns>
+        public string ToJson()
+        {
+            return JsonSerializer.Serialize(this, JsonSerializerSettings.CurrentOptions);
+        }
+
+        /// <summary>
+        /// Returns a string representation of this <see cref="LogoutRequest"/> instance
+        /// with the refresh token redacted to prevent accidental secret leakage in logs.
+        /// </summary>
+        /// <returns>A string representation with the refresh token replaced by "[REDACTED]".</returns>
+        public override string ToString()
+        {
+            return $"{{\"refreshToken\":\"[REDACTED]\"}}";
+        }
+
+        /// <summary>
+        /// Creates a <see cref="LogoutRequest"/> instance from a JSON string.
+        /// </summary>
+        /// <param name="json">The JSON string to deserialize.</param>
+        /// <returns>A <see cref="LogoutRequest"/> instance.</returns>
+        /// <exception cref="ArgumentException">Thrown when the JSON cannot be deserialized into a <see cref="LogoutRequest"/>.</exception>
+        public static LogoutRequest FromJson(string json)
+        {
+            try
+            {
+                LogoutRequest? result = JsonSerializer.Deserialize<LogoutRequest>(json, JsonSerializerSettings.CurrentOptions);
+
+                if (result == null)
+                {
+                    throw new ArgumentException($"Failed to deserialize {nameof(LogoutRequest)} from the provided JSON.");
+                }
+
+                return result;
+            }
+            catch (JsonException)
+            {
+                throw new ArgumentException($"Failed to deserialize {nameof(LogoutRequest)} from the provided JSON.");
+            }
+        }
+    }
+}

--- a/EasyReasy.Auth/LogoutRequest.cs
+++ b/EasyReasy.Auth/LogoutRequest.cs
@@ -5,7 +5,7 @@ namespace EasyReasy.Auth
     /// <summary>
     /// Request model for logging out by revoking a refresh token family.
     /// </summary>
-    public class LogoutRequest
+    public sealed class LogoutRequest
     {
         /// <summary>
         /// Gets the refresh token whose family should be invalidated.

--- a/EasyReasy.Auth/LogoutResult.cs
+++ b/EasyReasy.Auth/LogoutResult.cs
@@ -1,0 +1,58 @@
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// Represents the result of a logout operation.
+    /// Use the static factory methods <see cref="Known"/> and <see cref="Unknown"/> to create instances.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately does not carry the raw refresh token, so that consumer code logging the whole result
+    /// cannot accidentally leak secrets.
+    /// </remarks>
+    public sealed class LogoutResult
+    {
+        /// <summary>
+        /// Whether the supplied refresh token matched a stored token and a family was invalidated.
+        /// <c>false</c> means the token was null, empty, or unknown to the store — the operation was a no-op.
+        /// </summary>
+        public bool WasKnown { get; }
+
+        /// <summary>
+        /// The subject identifier (user id) associated with the invalidated family.
+        /// Only populated when <see cref="WasKnown"/> is true.
+        /// </summary>
+        public string? Subject { get; }
+
+        /// <summary>
+        /// The family identifier that was invalidated.
+        /// Only populated when <see cref="WasKnown"/> is true.
+        /// </summary>
+        public string? FamilyId { get; }
+
+        private LogoutResult(bool wasKnown, string? subject, string? familyId)
+        {
+            WasKnown = wasKnown;
+            Subject = subject;
+            FamilyId = familyId;
+        }
+
+        /// <summary>
+        /// Creates a result representing a logout that invalidated a known token family.
+        /// </summary>
+        /// <param name="subject">The subject identifier (user id) associated with the invalidated family.</param>
+        /// <param name="familyId">The family identifier that was invalidated.</param>
+        /// <returns>A <see cref="LogoutResult"/> with <see cref="WasKnown"/> set to <c>true</c>.</returns>
+        public static LogoutResult Known(string subject, string familyId)
+        {
+            return new LogoutResult(true, subject, familyId);
+        }
+
+        /// <summary>
+        /// Creates a result representing a logout call that did not match any stored token (null, empty, or unknown).
+        /// </summary>
+        /// <returns>A <see cref="LogoutResult"/> with <see cref="WasKnown"/> set to <c>false</c>.</returns>
+        public static LogoutResult Unknown()
+        {
+            return new LogoutResult(false, null, null);
+        }
+    }
+}

--- a/EasyReasy.Auth/README.md
+++ b/EasyReasy.Auth/README.md
@@ -42,7 +42,7 @@ builder.Services.AddEasyReasyAuth(jwtSecret, options =>
     options.Issuer = "my-issuer";
 });
 
-var app = builder.Build();
+WebApplication app = builder.Build();
 app.UseEasyReasyAuth(); // Progressive delay enabled by default
 ```
 
@@ -75,58 +75,78 @@ public class MyAuthService : IAuthRequestValidationService
         _passwordHasher = passwordHasher;
     }
 
-    public async Task<AuthResponse?> ValidateApiKeyRequestAsync(ApiKeyAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
+    public async Task<ApiKeyAuthResult> ValidateApiKeyRequestAsync(ApiKeyAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
     {
         // Validate API key (e.g., check database, external service, etc.)
-        var user = await _userRepository.GetByApiKeyAsync(request.ApiKey);
-        if (user == null) return null;
+        User? user = await _userRepository.GetByApiKeyAsync(request.ApiKey);
+        if (user == null)
+        {
+            return ApiKeyAuthResult.Failed(ApiKeyAuthFailureReason.UnknownKey);
+        }
 
         // Extract tenant ID from header if available
         string? tenantId = user.TenantId;
-        if (httpContext?.Request.Headers.TryGetValue("X-Tenant-ID", out var headerTenantId) == true)
+        if (httpContext?.Request.Headers.TryGetValue("X-Tenant-ID", out StringValues headerTenantId) == true)
         {
             tenantId = headerTenantId.ToString();
         }
 
-        // Create JWT token
+        // Create JWT token — only include the tenant_id claim if we actually have a value.
+        List<Claim> claims = new List<Claim>();
+        if (tenantId != null)
+        {
+            claims.Add(new Claim("tenant_id", tenantId));
+        }
+
         DateTime expiresAt = DateTime.UtcNow.AddHours(1);
         string token = jwtTokenService.CreateToken(
             subject: user.Id,
             authType: "apikey",
-            additionalClaims: new[] { new Claim("tenant_id", tenantId) },
+            additionalClaims: claims,
             roles: user.Roles.ToArray(),
             expiresAt: expiresAt);
 
-        return new AuthResponse(token, expiresAt.ToString("o"));
+        return ApiKeyAuthResult.Succeeded(new AuthResponse(token, expiresAt.ToString("o")), user.Id);
     }
 
-    public async Task<AuthResponse?> ValidateLoginRequestAsync(LoginAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
+    public async Task<LoginResult> ValidateLoginRequestAsync(LoginAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
     {
         // Validate username/password
-        var user = await _userRepository.GetByUsernameAsync(request.Username);
-        if (user == null) return null;
+        User? user = await _userRepository.GetByUsernameAsync(request.Username);
+        if (user == null)
+        {
+            // Populate AttemptedSubject so audit logs can attribute the failed attempt.
+            return LoginResult.Failed(LoginFailureReason.UnknownUser, attemptedSubject: request.Username);
+        }
 
-        // Validate password
         if (!_passwordHasher.ValidatePassword(request.Password, user.PasswordHash))
-            return null;
+        {
+            return LoginResult.Failed(LoginFailureReason.InvalidCredentials, attemptedSubject: user.Id);
+        }
 
         // Extract tenant ID from header if available
         string? tenantId = user.TenantId;
-        if (httpContext?.Request.Headers.TryGetValue("X-Tenant-ID", out var headerTenantId) == true)
+        if (httpContext?.Request.Headers.TryGetValue("X-Tenant-ID", out StringValues headerTenantId) == true)
         {
             tenantId = headerTenantId.ToString();
         }
 
-        // Create JWT token
+        // Create JWT token — only include the tenant_id claim if we actually have a value.
+        List<Claim> claims = new List<Claim>();
+        if (tenantId != null)
+        {
+            claims.Add(new Claim("tenant_id", tenantId));
+        }
+
         DateTime expiresAt = DateTime.UtcNow.AddHours(1);
         string token = jwtTokenService.CreateToken(
             subject: user.Id,
             authType: "user",
-            additionalClaims: new[] { new Claim("tenant_id", tenantId) },
+            additionalClaims: claims,
             roles: user.Roles.ToArray(),
             expiresAt: expiresAt);
 
-        return new AuthResponse(token, expiresAt.ToString("o"));
+        return LoginResult.Succeeded(new AuthResponse(token, expiresAt.ToString("o")), user.Id);
     }
 }
 ```
@@ -148,7 +168,7 @@ builder.Services.AddSingleton<IPasswordHasher, SecurePasswordHasher>();
 // 3. Register validation service (use AddScoped for services with database dependencies)
 builder.Services.AddScoped<IAuthRequestValidationService, MyAuthService>();
 
-var app = builder.Build();
+WebApplication app = builder.Build();
 
 // 4. Configure middleware (UseEasyReasyAuth includes UseAuthentication/UseAuthorization)
 app.UseEasyReasyAuth();
@@ -177,58 +197,80 @@ The `IAuthRequestValidationService` methods receive an optional `HttpContext` pa
 
 **Example: Extracting Tenant ID from Headers**
 ```csharp
-public async Task<AuthResponse?> ValidateApiKeyRequestAsync(ApiKeyAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
+public async Task<ApiKeyAuthResult> ValidateApiKeyRequestAsync(ApiKeyAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
 {
     // Validate API key
-    var user = await _userRepository.GetByApiKeyAsync(request.ApiKey);
-    if (user == null) return null;
+    User? user = await _userRepository.GetByApiKeyAsync(request.ApiKey);
+    if (user == null)
+    {
+        return ApiKeyAuthResult.Failed(ApiKeyAuthFailureReason.UnknownKey);
+    }
 
     // Extract tenant ID from header
     string? tenantId = null;
-    if (httpContext?.Request.Headers.TryGetValue("X-Tenant-ID", out var headerTenantId) == true)
+    if (httpContext?.Request.Headers.TryGetValue("X-Tenant-ID", out StringValues headerTenantId) == true)
     {
         tenantId = headerTenantId.ToString();
     }
 
-    // Create JWT token with tenant information
+    // Only include the tenant_id claim if we have a value — avoid writing empty-string claims.
+    List<Claim> claims = new List<Claim>();
+    if (tenantId != null)
+    {
+        claims.Add(new Claim("tenant_id", tenantId));
+    }
+
     DateTime expiresAt = DateTime.UtcNow.AddHours(1);
     string token = jwtTokenService.CreateToken(
         subject: user.Id,
         authType: "apikey",
-        additionalClaims: new[] { new Claim("tenant_id", tenantId) },
+        additionalClaims: claims,
         roles: user.Roles.ToArray(),
         expiresAt: expiresAt);
 
-    return new AuthResponse(token, expiresAt.ToString("o"));
+    return ApiKeyAuthResult.Succeeded(new AuthResponse(token, expiresAt.ToString("o")), user.Id);
 }
 ```
 
 **Example: Accessing Query Parameters**
 ```csharp
-public async Task<AuthResponse?> ValidateLoginRequestAsync(LoginAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
+public async Task<LoginResult> ValidateLoginRequestAsync(LoginAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
 {
     // Validate credentials
-    var user = await _userRepository.GetByUsernameAsync(request.Username);
-    if (user == null || !VerifyPassword(request.Password, user.PasswordHash)) 
-        return null;
+    User? user = await _userRepository.GetByUsernameAsync(request.Username);
+    if (user == null)
+    {
+        return LoginResult.Failed(LoginFailureReason.UnknownUser, attemptedSubject: request.Username);
+    }
+
+    if (!_passwordHasher.ValidatePassword(request.Password, user.PasswordHash))
+    {
+        return LoginResult.Failed(LoginFailureReason.InvalidCredentials, attemptedSubject: user.Id);
+    }
 
     // Extract organization from query parameter
     string? organization = httpContext?.Request.Query["org"].ToString();
 
-    // Create JWT token with organization information
+    // Only include claims for values we actually have.
+    List<Claim> claims = new List<Claim>();
+    if (user.TenantId != null)
+    {
+        claims.Add(new Claim("tenant_id", user.TenantId));
+    }
+    if (organization != null)
+    {
+        claims.Add(new Claim("organization", organization));
+    }
+
     DateTime expiresAt = DateTime.UtcNow.AddHours(1);
     string token = jwtTokenService.CreateToken(
         subject: user.Id,
         authType: "user",
-        additionalClaims: new[] 
-        { 
-            new Claim("tenant_id", user.TenantId),
-            new Claim("organization", organization)
-        },
+        additionalClaims: claims,
         roles: user.Roles.ToArray(),
         expiresAt: expiresAt);
 
-    return new AuthResponse(token, expiresAt.ToString("o"));
+    return LoginResult.Succeeded(new AuthResponse(token, expiresAt.ToString("o")), user.Id);
 }
 ```
 
@@ -336,7 +378,7 @@ public class MyRefreshTokenStore : IRefreshTokenStore
     public Task<StoredRefreshToken?> GetByTokenHashAsync(string tokenHash, CancellationToken cancellationToken = default) { /* SELECT by hash */ }
     public Task<bool> MarkAsConsumedAsync(string tokenHash, DateTime consumedAt, CancellationToken cancellationToken = default) { /* see note below */ }
     public Task InvalidateFamilyAsync(string familyId, CancellationToken cancellationToken = default) { /* UPDATE SET invalidated WHERE family_id = ... */ }
-    public Task InvalidateAllFamiliesForUserAsync(string subject, CancellationToken cancellationToken = default) { /* UPDATE SET invalidated WHERE subject = ... AND invalidated = false */ }
+    public Task<int> InvalidateAllFamiliesForUserAsync(string subject, CancellationToken cancellationToken = default) { /* UPDATE SET invalidated WHERE subject = ... AND invalidated = false; return affected-family count */ }
 }
 ```
 
@@ -354,21 +396,40 @@ This creates `POST /api/auth/refresh` which accepts `{ "refreshToken": "..." }` 
 
 The logout endpoint (`POST /api/auth/logout`) is enabled by default when you call `AddAuthEndpoints` — see the Logout section below.
 
-3. **Issue refresh tokens in your validation service** by injecting `IRefreshTokenService`:
+3. **Issue refresh tokens in your validation service** by injecting `IRefreshTokenService` alongside whatever user repository / password hasher you already use:
 ```csharp
 public class MyAuthService : IAuthRequestValidationService
 {
+    private readonly IUserRepository _userRepository;
+    private readonly IPasswordHasher _passwordHasher;
     private readonly IRefreshTokenService _refreshTokenService;
 
-    public MyAuthService(IRefreshTokenService refreshTokenService)
+    public MyAuthService(
+        IUserRepository userRepository,
+        IPasswordHasher passwordHasher,
+        IRefreshTokenService refreshTokenService)
     {
+        _userRepository = userRepository;
+        _passwordHasher = passwordHasher;
         _refreshTokenService = refreshTokenService;
     }
 
-    public async Task<AuthResponse?> ValidateLoginRequestAsync(
+    public async Task<LoginResult> ValidateLoginRequestAsync(
         LoginAuthRequest request, IJwtTokenService jwtTokenService, HttpContext? httpContext = null)
     {
-        // ... validate credentials, create access token ...
+        User? user = await _userRepository.GetByUsernameAsync(request.Username);
+        if (user == null)
+        {
+            // Populate AttemptedSubject so audit logs can attribute the failed attempt.
+            return LoginResult.Failed(LoginFailureReason.UnknownUser, attemptedSubject: request.Username);
+        }
+
+        if (!_passwordHasher.ValidatePassword(request.Password, user.PasswordHash))
+        {
+            return LoginResult.Failed(LoginFailureReason.InvalidCredentials, attemptedSubject: user.Id);
+        }
+
+        // ... create access token (see the main example) ...
 
         string refreshToken = await _refreshTokenService.CreateRefreshTokenAsync(
             subject: user.Id,
@@ -376,7 +437,7 @@ public class MyAuthService : IAuthRequestValidationService
             serializedClaims: RefreshTokenService.SerializeClaims(claims),
             serializedRoles: RefreshTokenService.SerializeRoles(roles));
 
-        return new AuthResponse(token, expiresAt.ToString("o"), refreshToken);
+        return LoginResult.Succeeded(new AuthResponse(token, expiresAt.ToString("o"), refreshToken), user.Id);
     }
 }
 ```
@@ -410,7 +471,7 @@ For other stores (Redis, MongoDB, etc.), use the equivalent atomic compare-and-s
 
 **Logout endpoint (`POST /api/auth/logout`)** — revokes the refresh token family for a supplied token so that even a captured refresh token can no longer mint new access tokens.
 
-- Enabled by default when you call `AddAuthEndpoints`. Disable with `allowLogout: false`.
+- Enabled by default when you call `AddAuthEndpoints`. Because it's on by default you **must** register `IRefreshTokenService` (e.g. `builder.Services.AddRefreshTokenService<MyStore>()`) — otherwise `AddAuthEndpoints` throws at startup. Disable with `allowLogout: false` if you don't need logout.
 - Accepts `{ "refreshToken": "..." }` (same shape as `/refresh`).
 - Anonymous — no access token required. This makes logout-on-expired-access-token still work.
 - Always returns `204 No Content`, even for unknown, null, or already-invalidated tokens — the response body does not reveal whether the token was known to the server. A theoretical timing side channel exists (a hit performs one extra write) but with 256-bit random tokens it is not a practical attack surface.
@@ -434,6 +495,11 @@ public class AccountService
 {
     private readonly IRefreshTokenService _refreshTokenService;
 
+    public AccountService(IRefreshTokenService refreshTokenService)
+    {
+        _refreshTokenService = refreshTokenService;
+    }
+
     public async Task ChangePasswordAsync(string userId, string newPassword)
     {
         // ... hash and persist new password ...
@@ -445,6 +511,129 @@ public class AccountService
 ```
 
 The library does not expose an HTTP endpoint for admins to revoke other users' sessions — build your own around `InvalidateAllSessionsAsync` if you need one.
+
+### 10. Security Audit Logging (ISO 27001 A.9 / A.12)
+
+Every authentication event the library surfaces — success or failure — is reported through a single optional DI service: `IAuthAuditLogger`. Register an implementation and the built-in endpoints (plus `RefreshTokenService.InvalidateAllSessionsAsync`) will invoke it with a structured result object.
+
+| Event | Hook | Control | Typical data to log |
+|---|---|---|---|
+| Successful / failed username+password login | `OnLoginAsync(httpContext, LoginResult)` | ISO 27001 A.12.4.1 | outcome, `AttemptedSubject`, `FailureReason`, IP, User-Agent, time |
+| Successful / failed API key auth | `OnApiKeyAuthAsync(httpContext, ApiKeyAuthResult)` | ISO 27001 A.12.4.1 | outcome, `AttemptedClientId`, `FailureReason`, IP, User-Agent, time |
+| Refresh (incl. `TheftDetected`) | `OnRefreshAsync(httpContext, RefreshResult)` | ISO 27001 A.12.4.1 | outcome, `Subject`, `FamilyId`, `FailureReason`, IP, time |
+| Logout | `OnLogoutAsync(httpContext, LogoutResult)` | ISO 27001 A.9.2.6 | `WasKnown`, `Subject`, `FamilyId`, IP, time |
+| Bulk session revocation | `OnSessionsInvalidatedAsync(SessionRevocationResult)` | ISO 27001 A.9.2.6 | `Subject`, `InvalidatedFamilyCount`, time |
+
+All methods have default no-op implementations — implement only the events you care about. The result objects deliberately never carry a raw password or a raw API key, so failure records are safe to serialise to your log store.
+
+⚠️ **Do not serialise the whole result object on the success path.** `LoginResult` and `ApiKeyAuthResult` embed an `AuthResponse` that carries the issued JWT access token and (when refresh tokens are enabled) the raw refresh token — both are bearer credentials. Log **metadata** from the result (`Success`, `AttemptedSubject` / `AttemptedClientId`, `FailureReason`) — never log `result.AuthResponse` with a structured logger's destructuring syntax (e.g. Serilog `{@result}`) or `JsonSerializer.Serialize(result)`. The example below follows the right pattern.
+
+```csharp
+public class MyAuditLogger : IAuthAuditLogger
+{
+    private readonly ILogger<MyAuditLogger> _logger;
+
+    public MyAuditLogger(ILogger<MyAuditLogger> logger) { _logger = logger; }
+
+    public Task OnLoginAsync(HttpContext ctx, LoginResult result)
+    {
+        _logger.LogInformation(
+            "auth.login {Outcome} subject={Subject} reason={Reason} ip={Ip}",
+            result.Success ? "success" : "failure",
+            result.AttemptedSubject,
+            result.FailureReason,
+            ctx.Connection.RemoteIpAddress);
+        return Task.CompletedTask;
+    }
+
+    public Task OnRefreshAsync(HttpContext? ctx, RefreshResult result)
+    {
+        // TheftDetected is particularly worth alerting on.
+        _logger.LogInformation(
+            "auth.refresh {Outcome} subject={Subject} family={Family} reason={Reason}",
+            result.Success ? "success" : "failure",
+            result.Subject, result.FamilyId, result.FailureReason);
+        return Task.CompletedTask;
+    }
+
+    public Task OnLogoutAsync(HttpContext? ctx, LogoutResult result)
+    {
+        if (result.WasKnown)
+        {
+            _logger.LogInformation(
+                "auth.logout subject={Subject} family={Family}",
+                result.Subject, result.FamilyId);
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task OnSessionsInvalidatedAsync(SessionRevocationResult result)
+    {
+        _logger.LogInformation(
+            "auth.sessions_revoked subject={Subject} count={Count}",
+            result.Subject, result.InvalidatedFamilyCount);
+        return Task.CompletedTask;
+    }
+}
+
+// Program.cs
+builder.Services.AddSingleton<IAuthAuditLogger, MyAuditLogger>();
+```
+
+The audit logger runs in the request scope, so implementations may resolve scoped dependencies. Implementations must not throw — an exception will propagate out of the endpoint and turn a successful auth into a 500.
+
+### 11. Sensitive Request Bodies (do not log)
+
+Four endpoints accept secrets in the request body. Exclude them from any body-logging middleware you run:
+
+| Path | Secret in body |
+|---|---|
+| `POST /api/auth/login` | password |
+| `POST /api/auth/apikey` | API key |
+| `POST /api/auth/refresh` | refresh token |
+| `POST /api/auth/logout` | refresh token |
+
+The library already redacts these via `ToString()` on the request DTOs (so structured logging that serialises the DTO object is safe). The risk is raw-stream logging that reads the request body before model binding.
+
+Define a shared path-matching helper and reuse it everywhere you exclude sensitive paths. In a top-level `Program.cs` this is a local function; inside a class it should be a `private static` method.
+
+```csharp
+// Program.cs (top-level statements) — local function
+static bool IsSensitiveAuthPath(PathString path) =>
+    path.StartsWithSegments("/api/auth/login") ||
+    path.StartsWithSegments("/api/auth/apikey") ||
+    path.StartsWithSegments("/api/auth/refresh") ||
+    path.StartsWithSegments("/api/auth/logout");
+```
+
+**`Microsoft.AspNetCore.HttpLogging`**
+
+```csharp
+builder.Services.AddHttpLogging(options =>
+{
+    options.LoggingFields = HttpLoggingFields.All;
+    options.MediaTypeOptions.AddText("application/json");
+});
+
+app.UseWhen(
+    ctx => !IsSensitiveAuthPath(ctx.Request.Path),
+    branch => branch.UseHttpLogging());
+```
+
+**Serilog request logging**
+
+```csharp
+app.UseSerilogRequestLogging(options =>
+{
+    options.EnrichDiagnosticContext = (diag, ctx) =>
+    {
+        if (IsSensitiveAuthPath(ctx.Request.Path)) return;
+        // only enrich with body contents for non-sensitive paths
+    };
+});
+```
+
+**OpenTelemetry** — ensure any `AspNetCoreInstrumentationOptions.EnrichWithHttpRequest` callback that captures request bodies checks the same path list.
 
 ## Advanced Configuration
 
@@ -573,19 +762,46 @@ For more details, see XML comments in the code or explore the source. This libra
 
 ## Migration from 3.x
 
-Version 4.0.0 introduces breaking changes:
+Version 4.0.0 introduces breaking changes. All are in service of structured results that flow into `IAuthAuditLogger` — the new optional DI service that backs ISO 27001–style security audit logging.
+
+### Validation Service
+- **`IAuthRequestValidationService` return types changed**:
+  - `ValidateLoginRequestAsync` now returns `Task<LoginResult>` (was `Task<AuthResponse?>`).
+  - `ValidateApiKeyRequestAsync` now returns `Task<ApiKeyAuthResult>` (was `Task<AuthResponse?>`).
+- **Both result types carry an `AttemptedSubject` / `AttemptedClientId`** that must be populated even on failure when knowable (e.g. `UnknownUser`, `UnknownKey`) so audit logs can attribute failed authentication attempts to an identifier. See Section 10 "Security Audit Logging".
+- **Neither result type carries the raw credential** (password / API key). Consumers logging the result cannot accidentally leak secrets.
+
+Migration shape:
+```csharp
+// Before
+return valid ? new AuthResponse(...) : null;
+
+// After
+return valid
+    ? LoginResult.Succeeded(new AuthResponse(...), user.Id)
+    : LoginResult.Failed(LoginFailureReason.InvalidCredentials, attemptedSubject: user.Id);
+```
 
 ### Refresh Token Store
-- **`IRefreshTokenStore` has a new required method**: `Task InvalidateAllFamiliesForUserAsync(string subject, CancellationToken cancellationToken)`. Existing implementations must add it — typically an `UPDATE refresh_tokens SET invalidated = true WHERE subject = @subject AND invalidated = false` (or the equivalent in your store).
-- **All `IRefreshTokenStore` methods now take `CancellationToken cancellationToken = default`**: `StoreAsync`, `GetByTokenHashAsync`, `MarkAsConsumedAsync`, `InvalidateFamilyAsync`. Existing implementations must add the parameter to each signature. Callers relying on the default value require no changes.
+- **`IRefreshTokenStore.InvalidateAllFamiliesForUserAsync`** is a new required method and returns `Task<int>` (count of families invalidated), flowing into `SessionRevocationResult.InvalidatedFamilyCount`. Typical SQL: `UPDATE refresh_tokens SET invalidated = true WHERE subject = @subject AND invalidated = false` — return the distinct-family count.
+- **All `IRefreshTokenStore` methods now take `CancellationToken cancellationToken = default`**: `StoreAsync`, `GetByTokenHashAsync`, `MarkAsConsumedAsync`, `InvalidateFamilyAsync`. Callers relying on the default value require no changes; custom implementations must add the parameter.
 
 ### Refresh Token Service
-- **The existing `IRefreshTokenService` methods now take `CancellationToken cancellationToken = default`**: `CreateRefreshTokenAsync`, `RefreshAsync`. Because the token is appended with a default value, existing callers require no changes — but custom `IRefreshTokenService` implementations must add the parameter to each override.
-- **Two new methods on `IRefreshTokenService`, both also with `CancellationToken cancellationToken = default`**: `LogoutAsync(string refreshToken, …)` and `InvalidateAllSessionsAsync(string subject, …)`. Available on the library-provided `RefreshTokenService` implementation — no consumer action needed unless you implement the service yourself.
+- **`IRefreshTokenService.LogoutAsync` and `IRefreshTokenService.InvalidateAllSessionsAsync` are new additions in 4.0.0** (not renames of pre-3.x methods). Custom implementations of `IRefreshTokenService` must add both — the built-in `RefreshTokenService` already implements them.
+- **`RefreshAsync` signature changed**: `Task<RefreshResult> RefreshAsync(string refreshToken, IJwtTokenService jwtTokenService, HttpContext? httpContext = null, CancellationToken cancellationToken = default)`. The new `httpContext` parameter flows into `IAuthAuditLogger.OnRefreshAsync`; pass `null` for programmatic refreshes. Existing positional callers of just `(refreshToken, jwtTokenService)` compile unchanged.
+- **`LogoutAsync` signature**: `Task<LogoutResult> LogoutAsync(string? refreshToken, HttpContext? httpContext = null, CancellationToken cancellationToken = default)`. The built-in endpoint still returns `204` on the wire; the structured result flows into `IAuthAuditLogger.OnLogoutAsync`. `refreshToken` is nullable — null/empty is a no-op. `httpContext` is null when called programmatically.
+- **`InvalidateAllSessionsAsync` signature**: `Task<SessionRevocationResult> InvalidateAllSessionsAsync(string subject, CancellationToken cancellationToken = default)`. Returns the count of families invalidated, fed into `IAuthAuditLogger.OnSessionsInvalidatedAsync`.
+- **`CreateRefreshTokenAsync` now takes `CancellationToken cancellationToken = default`**. Existing callers are unaffected; custom implementations must add the parameter.
 
 ### Auth Endpoints
-- **`AddAuthEndpoints` signature extended**: new `bool allowLogout = true` parameter controls the `POST /api/auth/logout` endpoint. Existing callers are unaffected because the default enables it; disable with `allowLogout: false` if undesired.
-- **Refresh and logout endpoints now honour `HttpContext.RequestAborted`**: a client disconnect will cancel the in-flight token operation instead of running it to completion. Custom store implementations should respect the supplied `CancellationToken` if they want the same behaviour.
+- **`AddAuthEndpoints` signature extended**: new `bool allowLogout = true` parameter controls the `POST /api/auth/logout` endpoint. **Breaking for existing callers who did not register `IRefreshTokenService`**: because the default enables logout, `AddAuthEndpoints` will throw at startup unless you either register a refresh token service (`builder.Services.AddRefreshTokenService<MyStore>()`) or explicitly opt out with `allowLogout: false`.
+- **`AddAuthEndpoints` startup validation is now conditional**: the check for `IAuthRequestValidationService` only fires when `allowApiKeys || allowUsernamePassword`; the check for `IRefreshTokenService` only fires when `allowRefresh || allowLogout`. A caller enabling only one endpoint family no longer needs to register services for the other.
+- **Refresh and logout endpoints now honour `HttpContext.RequestAborted`**: a client disconnect cancels the in-flight token operation.
+- **Audit hooks are split between the endpoint layer and the service layer**: `OnLoginAsync` and `OnApiKeyAuthAsync` are invoked by the endpoint (because `IAuthRequestValidationService` is consumer-implemented and cannot be guaranteed to call the hook). `OnRefreshAsync`, `OnLogoutAsync`, and `OnSessionsInvalidatedAsync` are invoked inside `RefreshTokenService`, so both HTTP and programmatic callers trigger them uniformly. See `IAuthAuditLogger` remarks.
+
+### New: `IAuthAuditLogger`
+- Opt-in DI service with default no-op methods — implement only what you need. See Section 10 "Security Audit Logging" for the full hook list and an example implementation. Registering one does not change wire behaviour; it only enables audit records.
+- **Register as singleton or scoped.** `RefreshTokenService` captures the logger at construction time, and the library registers the service as scoped — so both singleton and scoped loggers work correctly. Transient is wasteful but harmless. The only broken shape is a logger with a shorter lifetime than `IRefreshTokenService` itself, which in practice can only happen if you re-register the service as singleton while keeping a scoped logger.
 
 ## Migration from 2.x
 

--- a/EasyReasy.Auth/README.md
+++ b/EasyReasy.Auth/README.md
@@ -332,10 +332,11 @@ EasyReasy.Auth supports refresh token rotation with automatic theft detection vi
 ```csharp
 public class MyRefreshTokenStore : IRefreshTokenStore
 {
-    public Task StoreAsync(StoredRefreshToken refreshToken) { /* INSERT into DB */ }
-    public Task<StoredRefreshToken?> GetByTokenHashAsync(string tokenHash) { /* SELECT by hash */ }
-    public Task<bool> MarkAsConsumedAsync(string tokenHash, DateTime consumedAt) { /* see note below */ }
-    public Task InvalidateFamilyAsync(string familyId) { /* UPDATE SET invalidated WHERE family_id = ... */ }
+    public Task StoreAsync(StoredRefreshToken refreshToken, CancellationToken cancellationToken = default) { /* INSERT into DB */ }
+    public Task<StoredRefreshToken?> GetByTokenHashAsync(string tokenHash, CancellationToken cancellationToken = default) { /* SELECT by hash */ }
+    public Task<bool> MarkAsConsumedAsync(string tokenHash, DateTime consumedAt, CancellationToken cancellationToken = default) { /* see note below */ }
+    public Task InvalidateFamilyAsync(string familyId, CancellationToken cancellationToken = default) { /* UPDATE SET invalidated WHERE family_id = ... */ }
+    public Task InvalidateAllFamiliesForUserAsync(string subject, CancellationToken cancellationToken = default) { /* UPDATE SET invalidated WHERE subject = ... AND invalidated = false */ }
 }
 ```
 
@@ -350,6 +351,8 @@ app.AddAuthEndpoints(allowRefresh: true);
 // Or standalone: app.AddRefreshEndpoint();
 ```
 This creates `POST /api/auth/refresh` which accepts `{ "refreshToken": "..." }` and returns a new access + refresh token pair.
+
+The logout endpoint (`POST /api/auth/logout`) is enabled by default when you call `AddAuthEndpoints` — see the Logout section below.
 
 3. **Issue refresh tokens in your validation service** by injecting `IRefreshTokenService`:
 ```csharp
@@ -391,7 +394,7 @@ public class MyAuthService : IAuthRequestValidationService
 
 In SQL, use a conditional update and check affected rows:
 ```csharp
-public async Task<bool> MarkAsConsumedAsync(string tokenHash, DateTime consumedAt)
+public async Task<bool> MarkAsConsumedAsync(string tokenHash, DateTime consumedAt, CancellationToken cancellationToken = default)
 {
     // Only updates if consumed_at is still NULL — returns true if 1 row was affected
     int affected = await db.ExecuteAsync(
@@ -402,6 +405,46 @@ public async Task<bool> MarkAsConsumedAsync(string tokenHash, DateTime consumedA
 ```
 
 For other stores (Redis, MongoDB, etc.), use the equivalent atomic compare-and-set operation. If your store cannot guarantee atomicity, concurrent refresh requests could both succeed, issuing duplicate token pairs.
+
+### 9. Logout and Bulk Session Revocation
+
+**Logout endpoint (`POST /api/auth/logout`)** — revokes the refresh token family for a supplied token so that even a captured refresh token can no longer mint new access tokens.
+
+- Enabled by default when you call `AddAuthEndpoints`. Disable with `allowLogout: false`.
+- Accepts `{ "refreshToken": "..." }` (same shape as `/refresh`).
+- Anonymous — no access token required. This makes logout-on-expired-access-token still work.
+- Always returns `204 No Content`, even for unknown, null, or already-invalidated tokens — the response body does not reveal whether the token was known to the server. A theoretical timing side channel exists (a hit performs one extra write) but with 256-bit random tokens it is not a practical attack surface.
+- Stateless JWT access tokens remain valid until their `exp`. If you need immediate access-token invalidation, shorten the access token lifetime (e.g. 15 minutes) — that is the accepted industry trade-off and keeps the library design clean. Adding a JWT revocation list is explicitly out of scope.
+- **Anonymous logout trade-off**: because the endpoint requires only a refresh token, anyone who obtains any refresh token from a given family (including an expired or already-consumed one, e.g. from logs) can force-log-out that session. This is a deliberate choice — requiring an access token would block logout when the access token has expired, which is a common case. Callers who need stronger assurance should keep refresh tokens out of logs and treat them as secrets at least as sensitive as access tokens.
+
+```csharp
+// The logout endpoint is on by default; allowRefresh must be opted in explicitly.
+app.AddAuthEndpoints(allowRefresh: true);
+// Or standalone: app.AddLogoutEndpoint();
+```
+
+**Bulk session revocation (`IRefreshTokenService.InvalidateAllSessionsAsync`)** — invalidates every refresh token family for a subject at once. Intended for flows where all existing sessions must be kicked:
+
+- Password change
+- Role demotion
+- Admin-forced logout
+
+```csharp
+public class AccountService
+{
+    private readonly IRefreshTokenService _refreshTokenService;
+
+    public async Task ChangePasswordAsync(string userId, string newPassword)
+    {
+        // ... hash and persist new password ...
+
+        // Kick every existing session for this user.
+        await _refreshTokenService.InvalidateAllSessionsAsync(userId);
+    }
+}
+```
+
+The library does not expose an HTTP endpoint for admins to revoke other users' sessions — build your own around `InvalidateAllSessionsAsync` if you need one.
 
 ## Advanced Configuration
 
@@ -527,6 +570,22 @@ The progressive delay middleware helps protect your API from brute-force attacks
 ---
 
 For more details, see XML comments in the code or explore the source. This library is designed to be easy to use and secure enough for most uses cases by default.
+
+## Migration from 3.x
+
+Version 4.0.0 introduces breaking changes:
+
+### Refresh Token Store
+- **`IRefreshTokenStore` has a new required method**: `Task InvalidateAllFamiliesForUserAsync(string subject, CancellationToken cancellationToken)`. Existing implementations must add it — typically an `UPDATE refresh_tokens SET invalidated = true WHERE subject = @subject AND invalidated = false` (or the equivalent in your store).
+- **All `IRefreshTokenStore` methods now take `CancellationToken cancellationToken = default`**: `StoreAsync`, `GetByTokenHashAsync`, `MarkAsConsumedAsync`, `InvalidateFamilyAsync`. Existing implementations must add the parameter to each signature. Callers relying on the default value require no changes.
+
+### Refresh Token Service
+- **The existing `IRefreshTokenService` methods now take `CancellationToken cancellationToken = default`**: `CreateRefreshTokenAsync`, `RefreshAsync`. Because the token is appended with a default value, existing callers require no changes — but custom `IRefreshTokenService` implementations must add the parameter to each override.
+- **Two new methods on `IRefreshTokenService`, both also with `CancellationToken cancellationToken = default`**: `LogoutAsync(string refreshToken, …)` and `InvalidateAllSessionsAsync(string subject, …)`. Available on the library-provided `RefreshTokenService` implementation — no consumer action needed unless you implement the service yourself.
+
+### Auth Endpoints
+- **`AddAuthEndpoints` signature extended**: new `bool allowLogout = true` parameter controls the `POST /api/auth/logout` endpoint. Existing callers are unaffected because the default enables it; disable with `allowLogout: false` if undesired.
+- **Refresh and logout endpoints now honour `HttpContext.RequestAborted`**: a client disconnect will cancel the in-flight token operation instead of running it to completion. Custom store implementations should respect the supplied `CancellationToken` if they want the same behaviour.
 
 ## Migration from 2.x
 

--- a/EasyReasy.Auth/RefreshResult.cs
+++ b/EasyReasy.Auth/RefreshResult.cs
@@ -29,12 +29,36 @@ namespace EasyReasy.Auth
         /// </summary>
         public RefreshFailureReason? FailureReason { get; }
 
-        private RefreshResult(bool success, AuthResponse? authResponse, string? newRefreshToken, RefreshFailureReason? failureReason)
+        /// <summary>
+        /// The subject identifier (user id) associated with the refresh token.
+        /// Populated on success and on all failure reasons except <see cref="RefreshFailureReason.TokenNotFound"/>,
+        /// which has no associated stored token.
+        /// Intended to support security audit logging at the consumer site.
+        /// </summary>
+        public string? Subject { get; }
+
+        /// <summary>
+        /// The family identifier linking a chain of refresh tokens created by rotation.
+        /// Populated on success and on all failure reasons except <see cref="RefreshFailureReason.TokenNotFound"/>,
+        /// which has no associated stored token.
+        /// Intended to support security audit logging at the consumer site.
+        /// </summary>
+        public string? FamilyId { get; }
+
+        private RefreshResult(
+            bool success,
+            AuthResponse? authResponse,
+            string? newRefreshToken,
+            RefreshFailureReason? failureReason,
+            string? subject,
+            string? familyId)
         {
             Success = success;
             AuthResponse = authResponse;
             NewRefreshToken = newRefreshToken;
             FailureReason = failureReason;
+            Subject = subject;
+            FamilyId = familyId;
         }
 
         /// <summary>
@@ -42,20 +66,31 @@ namespace EasyReasy.Auth
         /// </summary>
         /// <param name="authResponse">The authentication response containing the new access token and refresh token.</param>
         /// <param name="newRefreshToken">The new raw refresh token.</param>
+        /// <param name="subject">The subject identifier (user id) associated with the refresh token. Optional; defaults to <c>null</c>.</param>
+        /// <param name="familyId">The family identifier linking rotated refresh tokens. Optional; defaults to <c>null</c>.</param>
         /// <returns>A successful <see cref="RefreshResult"/>.</returns>
-        public static RefreshResult Succeeded(AuthResponse authResponse, string newRefreshToken)
+        public static RefreshResult Succeeded(
+            AuthResponse authResponse,
+            string newRefreshToken,
+            string? subject = null,
+            string? familyId = null)
         {
-            return new RefreshResult(true, authResponse, newRefreshToken, null);
+            return new RefreshResult(true, authResponse, newRefreshToken, null, subject, familyId);
         }
 
         /// <summary>
         /// Creates a failed refresh result with a failure reason.
         /// </summary>
         /// <param name="reason">The reason the refresh operation failed.</param>
+        /// <param name="subject">The subject identifier (user id) associated with the refresh token, when available. Optional; defaults to <c>null</c>.</param>
+        /// <param name="familyId">The family identifier linking rotated refresh tokens, when available. Optional; defaults to <c>null</c>.</param>
         /// <returns>A failed <see cref="RefreshResult"/>.</returns>
-        public static RefreshResult Failed(RefreshFailureReason reason)
+        public static RefreshResult Failed(
+            RefreshFailureReason reason,
+            string? subject = null,
+            string? familyId = null)
         {
-            return new RefreshResult(false, null, null, reason);
+            return new RefreshResult(false, null, null, reason, subject, familyId);
         }
     }
 }

--- a/EasyReasy.Auth/RefreshTokenService.cs
+++ b/EasyReasy.Auth/RefreshTokenService.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
@@ -14,6 +15,7 @@ namespace EasyReasy.Auth
         private readonly IRefreshTokenStore _store;
         private readonly TimeSpan _refreshTokenLifetime;
         private readonly TimeSpan _accessTokenLifetime;
+        private readonly IAuthAuditLogger? _auditLogger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RefreshTokenService"/> class.
@@ -25,14 +27,24 @@ namespace EasyReasy.Auth
         /// <param name="accessTokenLifetime">
         /// The lifetime of access tokens created during refresh. Defaults to 1 hour if not specified.
         /// </param>
+        /// <param name="auditLogger">
+        /// Optional audit logger. When supplied, this service invokes the matching hook after every
+        /// <see cref="RefreshAsync"/> (<see cref="IAuthAuditLogger.OnRefreshAsync"/>),
+        /// <see cref="LogoutAsync"/> (<see cref="IAuthAuditLogger.OnLogoutAsync"/>), and
+        /// <see cref="InvalidateAllSessionsAsync"/> (<see cref="IAuthAuditLogger.OnSessionsInvalidatedAsync"/>) call
+        /// so consumers can emit ISO 27001 A.12.4.1 / A.9.2.6 audit records for both HTTP-driven and programmatic flows.
+        /// Lifetime must be at least as long as this service — see <see cref="IAuthAuditLogger"/> remarks.
+        /// </param>
         public RefreshTokenService(
             IRefreshTokenStore store,
             TimeSpan? refreshTokenLifetime = null,
-            TimeSpan? accessTokenLifetime = null)
+            TimeSpan? accessTokenLifetime = null,
+            IAuthAuditLogger? auditLogger = null)
         {
             _store = store ?? throw new ArgumentNullException(nameof(store));
             _refreshTokenLifetime = refreshTokenLifetime ?? TimeSpan.FromDays(30);
             _accessTokenLifetime = accessTokenLifetime ?? TimeSpan.FromHours(1);
+            _auditLogger = auditLogger;
         }
 
         /// <inheritdoc />
@@ -66,7 +78,19 @@ namespace EasyReasy.Auth
         }
 
         /// <inheritdoc />
-        public async Task<RefreshResult> RefreshAsync(string refreshToken, IJwtTokenService jwtTokenService, CancellationToken cancellationToken = default)
+        public async Task<RefreshResult> RefreshAsync(string refreshToken, IJwtTokenService jwtTokenService, HttpContext? httpContext = null, CancellationToken cancellationToken = default)
+        {
+            RefreshResult result = await ComputeRefreshAsync(refreshToken, jwtTokenService, cancellationToken);
+
+            if (_auditLogger != null)
+            {
+                await _auditLogger.OnRefreshAsync(httpContext, result);
+            }
+
+            return result;
+        }
+
+        private async Task<RefreshResult> ComputeRefreshAsync(string refreshToken, IJwtTokenService jwtTokenService, CancellationToken cancellationToken)
         {
             DateTime now = DateTime.UtcNow;
             string tokenHash = HashToken(refreshToken);
@@ -145,14 +169,26 @@ namespace EasyReasy.Auth
         }
 
         /// <inheritdoc />
-        public async Task LogoutAsync(string refreshToken, CancellationToken cancellationToken = default)
+        public async Task<LogoutResult> LogoutAsync(string? refreshToken, HttpContext? httpContext = null, CancellationToken cancellationToken = default)
+        {
+            LogoutResult result = await ComputeLogoutAsync(refreshToken, cancellationToken);
+
+            if (_auditLogger != null)
+            {
+                await _auditLogger.OnLogoutAsync(httpContext, result);
+            }
+
+            return result;
+        }
+
+        private async Task<LogoutResult> ComputeLogoutAsync(string? refreshToken, CancellationToken cancellationToken)
         {
             // A null or empty token can't map to any family — treat as a no-op so that
             // callers (including the unauthenticated HTTP endpoint) still see idempotent
             // 204 behaviour instead of a 500 from a hashing exception.
             if (string.IsNullOrEmpty(refreshToken))
             {
-                return;
+                return LogoutResult.Unknown();
             }
 
             string tokenHash = HashToken(refreshToken);
@@ -160,16 +196,27 @@ namespace EasyReasy.Auth
 
             if (storedToken == null)
             {
-                return;
+                return LogoutResult.Unknown();
             }
 
             await _store.InvalidateFamilyAsync(storedToken.FamilyId, cancellationToken);
+            return LogoutResult.Known(storedToken.Subject, storedToken.FamilyId);
         }
 
         /// <inheritdoc />
-        public Task InvalidateAllSessionsAsync(string subject, CancellationToken cancellationToken = default)
+        public async Task<SessionRevocationResult> InvalidateAllSessionsAsync(string subject, CancellationToken cancellationToken = default)
         {
-            return _store.InvalidateAllFamiliesForUserAsync(subject, cancellationToken);
+            ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+
+            int invalidatedCount = await _store.InvalidateAllFamiliesForUserAsync(subject, cancellationToken);
+            SessionRevocationResult result = new SessionRevocationResult(subject, invalidatedCount);
+
+            if (_auditLogger != null)
+            {
+                await _auditLogger.OnSessionsInvalidatedAsync(result);
+            }
+
+            return result;
         }
 
         /// <summary>

--- a/EasyReasy.Auth/RefreshTokenService.cs
+++ b/EasyReasy.Auth/RefreshTokenService.cs
@@ -81,20 +81,20 @@ namespace EasyReasy.Auth
             // Step 2: Token invalidated
             if (storedToken.IsInvalidated)
             {
-                return RefreshResult.Failed(RefreshFailureReason.TokenInvalidated);
+                return RefreshResult.Failed(RefreshFailureReason.TokenInvalidated, storedToken.Subject, storedToken.FamilyId);
             }
 
             // Step 3: Token already consumed — theft detected
             if (storedToken.ConsumedAt != null)
             {
                 await _store.InvalidateFamilyAsync(storedToken.FamilyId, cancellationToken);
-                return RefreshResult.Failed(RefreshFailureReason.TheftDetected);
+                return RefreshResult.Failed(RefreshFailureReason.TheftDetected, storedToken.Subject, storedToken.FamilyId);
             }
 
             // Step 4: Token expired
             if (storedToken.ExpiresAt <= now)
             {
-                return RefreshResult.Failed(RefreshFailureReason.TokenExpired);
+                return RefreshResult.Failed(RefreshFailureReason.TokenExpired, storedToken.Subject, storedToken.FamilyId);
             }
 
             // Step 5: Atomically mark old token as consumed — if another request already consumed it, treat as theft
@@ -102,7 +102,7 @@ namespace EasyReasy.Auth
             if (!consumed)
             {
                 await _store.InvalidateFamilyAsync(storedToken.FamilyId, cancellationToken);
-                return RefreshResult.Failed(RefreshFailureReason.TheftDetected);
+                return RefreshResult.Failed(RefreshFailureReason.TheftDetected, storedToken.Subject, storedToken.FamilyId);
             }
 
             // Step 6: Deserialize stored claims and roles, create new access token
@@ -141,7 +141,7 @@ namespace EasyReasy.Auth
                 accessTokenExpiresAt.ToString("O"),
                 newRawToken);
 
-            return RefreshResult.Succeeded(authResponse, newRawToken);
+            return RefreshResult.Succeeded(authResponse, newRawToken, storedToken.Subject, storedToken.FamilyId);
         }
 
         /// <inheritdoc />

--- a/EasyReasy.Auth/RefreshTokenService.cs
+++ b/EasyReasy.Auth/RefreshTokenService.cs
@@ -40,7 +40,8 @@ namespace EasyReasy.Auth
             string subject,
             string authType,
             string? serializedClaims,
-            string? serializedRoles)
+            string? serializedRoles,
+            CancellationToken cancellationToken = default)
         {
             string rawToken = GenerateToken();
             string tokenHash = HashToken(rawToken);
@@ -59,17 +60,17 @@ namespace EasyReasy.Auth
                 SerializedRoles = serializedRoles
             };
 
-            await _store.StoreAsync(storedToken);
+            await _store.StoreAsync(storedToken, cancellationToken);
 
             return rawToken;
         }
 
         /// <inheritdoc />
-        public async Task<RefreshResult> RefreshAsync(string refreshToken, IJwtTokenService jwtTokenService)
+        public async Task<RefreshResult> RefreshAsync(string refreshToken, IJwtTokenService jwtTokenService, CancellationToken cancellationToken = default)
         {
             DateTime now = DateTime.UtcNow;
             string tokenHash = HashToken(refreshToken);
-            StoredRefreshToken? storedToken = await _store.GetByTokenHashAsync(tokenHash);
+            StoredRefreshToken? storedToken = await _store.GetByTokenHashAsync(tokenHash, cancellationToken);
 
             // Step 1: Token not found
             if (storedToken == null)
@@ -86,7 +87,7 @@ namespace EasyReasy.Auth
             // Step 3: Token already consumed — theft detected
             if (storedToken.ConsumedAt != null)
             {
-                await _store.InvalidateFamilyAsync(storedToken.FamilyId);
+                await _store.InvalidateFamilyAsync(storedToken.FamilyId, cancellationToken);
                 return RefreshResult.Failed(RefreshFailureReason.TheftDetected);
             }
 
@@ -97,10 +98,10 @@ namespace EasyReasy.Auth
             }
 
             // Step 5: Atomically mark old token as consumed — if another request already consumed it, treat as theft
-            bool consumed = await _store.MarkAsConsumedAsync(tokenHash, now);
+            bool consumed = await _store.MarkAsConsumedAsync(tokenHash, now, cancellationToken);
             if (!consumed)
             {
-                await _store.InvalidateFamilyAsync(storedToken.FamilyId);
+                await _store.InvalidateFamilyAsync(storedToken.FamilyId, cancellationToken);
                 return RefreshResult.Failed(RefreshFailureReason.TheftDetected);
             }
 
@@ -132,7 +133,7 @@ namespace EasyReasy.Auth
                 SerializedRoles = storedToken.SerializedRoles
             };
 
-            await _store.StoreAsync(newStoredToken);
+            await _store.StoreAsync(newStoredToken, cancellationToken);
 
             // Step 8: Return success with new token pair
             AuthResponse authResponse = new AuthResponse(
@@ -141,6 +142,34 @@ namespace EasyReasy.Auth
                 newRawToken);
 
             return RefreshResult.Succeeded(authResponse, newRawToken);
+        }
+
+        /// <inheritdoc />
+        public async Task LogoutAsync(string refreshToken, CancellationToken cancellationToken = default)
+        {
+            // A null or empty token can't map to any family — treat as a no-op so that
+            // callers (including the unauthenticated HTTP endpoint) still see idempotent
+            // 204 behaviour instead of a 500 from a hashing exception.
+            if (string.IsNullOrEmpty(refreshToken))
+            {
+                return;
+            }
+
+            string tokenHash = HashToken(refreshToken);
+            StoredRefreshToken? storedToken = await _store.GetByTokenHashAsync(tokenHash, cancellationToken);
+
+            if (storedToken == null)
+            {
+                return;
+            }
+
+            await _store.InvalidateFamilyAsync(storedToken.FamilyId, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task InvalidateAllSessionsAsync(string subject, CancellationToken cancellationToken = default)
+        {
+            return _store.InvalidateAllFamiliesForUserAsync(subject, cancellationToken);
         }
 
         /// <summary>

--- a/EasyReasy.Auth/SessionRevocationResult.cs
+++ b/EasyReasy.Auth/SessionRevocationResult.cs
@@ -1,0 +1,30 @@
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// Represents the result of a bulk session revocation (e.g. password change, role demotion, admin-forced logout).
+    /// </summary>
+    public sealed class SessionRevocationResult
+    {
+        /// <summary>
+        /// The subject identifier (user id) whose sessions were revoked.
+        /// </summary>
+        public string Subject { get; }
+
+        /// <summary>
+        /// The number of refresh token families that were invalidated by the operation.
+        /// A value of zero means the subject had no active sessions at the time of the call.
+        /// </summary>
+        public int InvalidatedFamilyCount { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SessionRevocationResult"/> class.
+        /// </summary>
+        /// <param name="subject">The subject identifier (user id) whose sessions were revoked.</param>
+        /// <param name="invalidatedFamilyCount">The number of refresh token families that were invalidated.</param>
+        public SessionRevocationResult(string subject, int invalidatedFamilyCount)
+        {
+            Subject = subject;
+            InvalidatedFamilyCount = invalidatedFamilyCount;
+        }
+    }
+}

--- a/EasyReasy.EnvironmentVariables.Tests/EnvironmentVariableHelperTests.cs
+++ b/EasyReasy.EnvironmentVariables.Tests/EnvironmentVariableHelperTests.cs
@@ -1151,7 +1151,7 @@ EXAMPLE_KEY2=example_value2
             string result = EnvironmentVariableHelper.GetExampleContent(typeof(TestEmptyConfiguration));
 
             // Assert
-            string expected = "# Use \"#\" to comment\r\n";
+            string expected = "# Use \"#\" to comment" + Environment.NewLine;
             Assert.AreEqual(expected, result);
         }
 


### PR DESCRIPTION
## Why?

Closes #7.

EasyReasy.Auth already supports refresh token rotation with per-family theft detection, but two primitives every consumer needs were missing: a way to revoke a single refresh token family (logout), and a way to revoke every family for a subject at once (for password change, role demotion, or admin-forced logout).

Both are generic auth concerns, so they belong in the library instead of being reinvented in each consuming app.

## What?

**Server (`EasyReasy.Auth` 3.1.0 → 4.0.0):**
- New `POST /api/auth/logout` endpoint — accepts a `LogoutRequest`, anonymous, idempotent, always 204.
- New `IRefreshTokenService.LogoutAsync(refreshToken)` — looks up the token, invalidates its family, silent on null/empty/unknown.
- New `IRefreshTokenService.InvalidateAllSessionsAsync(subject)` — thin wrapper over the store so app code doesn't need `IRefreshTokenStore` directly.
- New required `IRefreshTokenStore.InvalidateAllFamiliesForUserAsync(subject)` — the backing store for bulk invalidation.
- `CancellationToken cancellationToken = default` added to every method on both interfaces (breaking change, but 4.0.0 already is).
- Refresh and logout endpoints now honour `HttpContext.RequestAborted`.
- `AddAuthEndpoints` now has `allowLogout: true` by default (opt-out if undesired) and validates that `IRefreshTokenService` is registered when refresh or logout is enabled — fails loudly at startup rather than at first request.
- `.AllowAnonymous()` applied to all four auth endpoints for consistency and defence-in-depth against global auth policies.

**Client (`EasyReasy.Auth.Client` 1.5.0 → 1.6.0):**
- New `AuthorizedHttpClient.LogoutAsync()` — posts the current refresh token, then clears local auth state. Best-effort on HTTP failures. State-clearing is guaranteed via `try/finally` even on cancellation.
- New `logoutEndpoint` optional constructor parameter on all three constructors.
- New `LogoutRequest` DTO.

**Docs:**
- README sections added for logout, bulk session revocation, and the anonymous-logout trade-off.
- Migration-from-3.x section documenting every breaking change.

**Tests:**
- 8 new service-level tests covering `LogoutAsync` (valid / null / empty / unknown / rotated / consumed-but-not-invalidated / isolation) and `InvalidateAllSessionsAsync`.
- 5 new `LogoutRequest` DTO tests.
- 7 new client-side tests including a `TaskCompletionSource`-handshake cancellation test that locks in the "state always cleared" invariant.

## Challenges

- **Cancellation semantics on the client.** The first implementation caught only `HttpRequestException`, so a `TaskCanceledException` from `HttpClient.PostAsync` would skip the local state clean-up and leave the client authenticated. Restructured with an inner `try/finally` so state is always cleared once the logout sequence begins (after the internal lock is acquired). Documented the one case that isn't covered (cancellation during the lock wait itself).
- **Timing side channel on logout.** A hit performs one extra DB write compared to a miss. With 256-bit random tokens this is not a practical attack surface — equalising it would cost every consumer an extra SQL round-trip forever. Documented the trade-off instead.
- **Null-body robustness.** Minimal-API JSON binding doesn't enforce NRT on DTO properties, so `{}` or `{"refreshToken":null}` originally produced a 500 from `HashToken`. Guarded the service with an early null/empty check so the endpoint's 204 contract holds.

## Left for future work

- Admin "revoke another user's session" HTTP endpoint. Consumers who need this can build their own around `InvalidateAllSessionsAsync`.
- JWT revocation list / stateful access-token invalidation. The accepted industry trade-off is to shorten access-token lifetime instead; adding a revocation list is explicitly out of scope for this library.
- Collapsing the endpoint-path parameters on `AuthorizedHttpClient` constructors into an options record — good refactor but scope creep for this release.