### PR TITLE
Add IRefreshClaimsResolver for mid-session re-evaluation

### DIFF
--- a/EasyReasy.Auth.Tests/FakeRefreshClaimsResolver.cs
+++ b/EasyReasy.Auth.Tests/FakeRefreshClaimsResolver.cs
@@ -1,0 +1,35 @@
+namespace EasyReasy.Auth.Tests
+{
+    /// <summary>
+    /// Configurable <see cref="IRefreshClaimsResolver"/> for testing. Records every invocation
+    /// so tests can assert what context was passed, and can be configured to allow with
+    /// specific claims/roles, deny, or throw.
+    /// </summary>
+    internal sealed class FakeRefreshClaimsResolver : IRefreshClaimsResolver
+    {
+        private readonly Func<RefreshClaimsContext, RefreshClaimsDecision> _decide;
+
+        public List<RefreshClaimsContext> Calls { get; } = new List<RefreshClaimsContext>();
+        public List<CancellationToken> ReceivedCancellationTokens { get; } = new List<CancellationToken>();
+
+        public FakeRefreshClaimsResolver(Func<RefreshClaimsContext, RefreshClaimsDecision> decide)
+        {
+            _decide = decide;
+        }
+
+        public Task<RefreshClaimsDecision> ResolveAsync(RefreshClaimsContext context, CancellationToken cancellationToken)
+        {
+            Calls.Add(context);
+            ReceivedCancellationTokens.Add(cancellationToken);
+            try
+            {
+                RefreshClaimsDecision decision = _decide(context);
+                return Task.FromResult(decision);
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException<RefreshClaimsDecision>(ex);
+            }
+        }
+    }
+}

--- a/EasyReasy.Auth.Tests/RefreshTokenServiceClaimsResolverTests.cs
+++ b/EasyReasy.Auth.Tests/RefreshTokenServiceClaimsResolverTests.cs
@@ -1,0 +1,365 @@
+using Microsoft.AspNetCore.Http;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
+namespace EasyReasy.Auth.Tests
+{
+    [TestClass]
+    public class RefreshTokenServiceClaimsResolverTests
+    {
+        private const string TestSecret = "super_secret_key_12345_12345_12345";
+        private const string TestIssuer = "test-issuer";
+
+        private FakeRefreshTokenStore _store = null!;
+        private IJwtTokenService _jwtTokenService = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _store = new FakeRefreshTokenStore();
+            _jwtTokenService = new JwtTokenService(TestSecret, TestIssuer);
+        }
+
+        private RefreshTokenService BuildService(
+            IRefreshClaimsResolver? resolver = null,
+            IAuthAuditLogger? auditLogger = null)
+        {
+            return new RefreshTokenService(_store, auditLogger: auditLogger, claimsResolver: resolver);
+        }
+
+        private static FakeRefreshClaimsResolver AllowReturning(IEnumerable<Claim> claims, IEnumerable<string> roles)
+        {
+            return new FakeRefreshClaimsResolver(_ => RefreshClaimsDecision.Allow(claims, roles));
+        }
+
+        private static FakeRefreshClaimsResolver Denying()
+        {
+            return new FakeRefreshClaimsResolver(_ => RefreshClaimsDecision.Deny());
+        }
+
+        private static FakeRefreshClaimsResolver Throwing(Exception exception)
+        {
+            return new FakeRefreshClaimsResolver(_ => throw exception);
+        }
+
+        private static IEnumerable<Claim> DecodeClaims(string accessToken)
+        {
+            return new JwtSecurityTokenHandler().ReadJwtToken(accessToken).Claims;
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithNoResolver_ShouldPreserveStoredSerializedClaimsAndRolesOnNewRow()
+        {
+            List<Claim> claims = new List<Claim> { new Claim("tenant_id", "tenant-42") };
+            List<string> roles = new List<string> { "admin" };
+            string? serializedClaims = RefreshTokenService.SerializeClaims(claims);
+            string? serializedRoles = RefreshTokenService.SerializeRoles(roles);
+
+            RefreshTokenService service = BuildService();
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", serializedClaims, serializedRoles);
+
+            RefreshResult result = await service.RefreshAsync(rawToken, _jwtTokenService);
+
+            Assert.IsTrue(result.Success);
+            StoredRefreshToken newStored = _store.Tokens[RefreshTokenService.HashToken(result.NewRefreshToken!)];
+            Assert.AreEqual(serializedClaims, newStored.SerializedClaims);
+            Assert.AreEqual(serializedRoles, newStored.SerializedRoles);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithNoResolver_ShouldPlaceStoredClaimsAndRolesOnAccessToken()
+        {
+            List<Claim> claims = new List<Claim> { new Claim("tenant_id", "tenant-42") };
+            List<string> roles = new List<string> { "admin" };
+            string? serializedClaims = RefreshTokenService.SerializeClaims(claims);
+            string? serializedRoles = RefreshTokenService.SerializeRoles(roles);
+
+            RefreshTokenService service = BuildService();
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", serializedClaims, serializedRoles);
+
+            RefreshResult result = await service.RefreshAsync(rawToken, _jwtTokenService);
+
+            IEnumerable<Claim> issued = DecodeClaims(result.AuthResponse!.Token);
+            Assert.AreEqual(1, issued.Count(c => c.Type == "tenant_id" && c.Value == "tenant-42"));
+            Assert.AreEqual(1, issued.Count(c => c.Type == ClaimTypes.Role && c.Value == "admin"));
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithResolverReturningClaims_ShouldUseResolvedClaimsOnAccessToken()
+        {
+            FakeRefreshClaimsResolver resolver = AllowReturning(
+                new List<Claim> { new Claim("tenant_id", "tenant-99") },
+                Array.Empty<string>());
+            RefreshTokenService service = BuildService(resolver);
+
+            string? storedClaims = RefreshTokenService.SerializeClaims(new List<Claim> { new Claim("tenant_id", "tenant-42") });
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", storedClaims, null);
+
+            RefreshResult result = await service.RefreshAsync(rawToken, _jwtTokenService);
+
+            Assert.IsTrue(result.Success);
+            IEnumerable<Claim> issued = DecodeClaims(result.AuthResponse!.Token);
+            Assert.AreEqual(1, issued.Count(c => c.Type == "tenant_id" && c.Value == "tenant-99"));
+            Assert.AreEqual(0, issued.Count(c => c.Type == "tenant_id" && c.Value == "tenant-42"));
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithResolverReturningClaims_ShouldPersistResolvedClaimsForNextRotation()
+        {
+            // First refresh runs under a resolver that swaps tenant-42 for tenant-99. Then we
+            // drop the resolver and refresh again; the access token from that second hop must
+            // still carry tenant-99 — proving the resolved claims survived a full rotation,
+            // not just landed on the first issued JWT.
+            FakeRefreshClaimsResolver resolver = AllowReturning(
+                new List<Claim> { new Claim("tenant_id", "tenant-99") },
+                Array.Empty<string>());
+            RefreshTokenService serviceWithResolver = BuildService(resolver);
+            RefreshTokenService serviceWithoutResolver = BuildService();
+
+            string? storedClaims = RefreshTokenService.SerializeClaims(new List<Claim> { new Claim("tenant_id", "tenant-42") });
+            string firstToken = await serviceWithResolver.CreateRefreshTokenAsync("user-1", "user", storedClaims, null);
+
+            RefreshResult firstRefresh = await serviceWithResolver.RefreshAsync(firstToken, _jwtTokenService);
+            RefreshResult secondRefresh = await serviceWithoutResolver.RefreshAsync(firstRefresh.NewRefreshToken!, _jwtTokenService);
+
+            Assert.IsTrue(secondRefresh.Success);
+            IEnumerable<Claim> issued = DecodeClaims(secondRefresh.AuthResponse!.Token);
+            Assert.AreEqual(1, issued.Count(c => c.Type == "tenant_id" && c.Value == "tenant-99"));
+            Assert.AreEqual(0, issued.Count(c => c.Type == "tenant_id" && c.Value == "tenant-42"));
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithResolverReturningRoles_ShouldUseResolvedRolesOnAccessToken()
+        {
+            FakeRefreshClaimsResolver resolver = AllowReturning(
+                Array.Empty<Claim>(),
+                new List<string> { "user" });
+            RefreshTokenService service = BuildService(resolver);
+
+            string? storedRoles = RefreshTokenService.SerializeRoles(new List<string> { "admin" });
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", null, storedRoles);
+
+            RefreshResult result = await service.RefreshAsync(rawToken, _jwtTokenService);
+
+            Assert.IsTrue(result.Success);
+            IEnumerable<Claim> issued = DecodeClaims(result.AuthResponse!.Token);
+            Assert.AreEqual(1, issued.Count(c => c.Type == ClaimTypes.Role && c.Value == "user"));
+            Assert.AreEqual(0, issued.Count(c => c.Type == ClaimTypes.Role && c.Value == "admin"));
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithResolverAllowingEmpty_ShouldNullOutStoredSerializedFields()
+        {
+            // Stored row had tenant_id + role. Resolver returns Allow(empty, empty). The new
+            // stored row must reflect the resolver's "no claims, no roles" verdict — i.e. both
+            // serialized fields become null, NOT the original JSON. Pins the "Allow erases"
+            // semantic that subtly differs from the no-resolver pass-through path.
+            FakeRefreshClaimsResolver resolver = AllowReturning(Array.Empty<Claim>(), Array.Empty<string>());
+            RefreshTokenService service = BuildService(resolver);
+
+            string? storedClaims = RefreshTokenService.SerializeClaims(new List<Claim> { new Claim("tenant_id", "tenant-42") });
+            string? storedRoles = RefreshTokenService.SerializeRoles(new List<string> { "admin" });
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", storedClaims, storedRoles);
+
+            RefreshResult result = await service.RefreshAsync(rawToken, _jwtTokenService);
+
+            StoredRefreshToken newStored = _store.Tokens[RefreshTokenService.HashToken(result.NewRefreshToken!)];
+            Assert.IsNull(newStored.SerializedClaims);
+            Assert.IsNull(newStored.SerializedRoles);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithResolverDenying_ShouldReturnDeniedByResolverFailure()
+        {
+            FakeRefreshClaimsResolver resolver = Denying();
+            RefreshTokenService service = BuildService(resolver);
+
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string expectedFamilyId = _store.Tokens[RefreshTokenService.HashToken(rawToken)].FamilyId;
+
+            RefreshResult result = await service.RefreshAsync(rawToken, _jwtTokenService);
+
+            Assert.IsFalse(result.Success);
+            Assert.AreEqual(RefreshFailureReason.DeniedByResolver, result.FailureReason);
+            Assert.AreEqual("user-1", result.Subject);
+            Assert.AreEqual(expectedFamilyId, result.FamilyId);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithResolverDenying_ShouldNotConsumeStoredToken()
+        {
+            FakeRefreshClaimsResolver resolver = Denying();
+            RefreshTokenService service = BuildService(resolver);
+
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string hash = RefreshTokenService.HashToken(rawToken);
+
+            await service.RefreshAsync(rawToken, _jwtTokenService);
+
+            Assert.IsNull(_store.Tokens[hash].ConsumedAt);
+            Assert.IsFalse(_store.Tokens[hash].IsInvalidated);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithResolverThrowing_ShouldPropagateException()
+        {
+            InvalidOperationException injected = new InvalidOperationException("resolver blew up");
+            FakeRefreshClaimsResolver resolver = Throwing(injected);
+            RefreshTokenService service = BuildService(resolver);
+
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", null, null);
+
+            InvalidOperationException thrown = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => service.RefreshAsync(rawToken, _jwtTokenService));
+            Assert.AreSame(injected, thrown);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithResolverThrowing_ShouldNotConsumeStoredToken()
+        {
+            FakeRefreshClaimsResolver resolver = Throwing(new InvalidOperationException("resolver blew up"));
+            RefreshTokenService service = BuildService(resolver);
+
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string hash = RefreshTokenService.HashToken(rawToken);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => service.RefreshAsync(rawToken, _jwtTokenService));
+
+            Assert.IsNull(_store.Tokens[hash].ConsumedAt);
+            Assert.IsFalse(_store.Tokens[hash].IsInvalidated);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithResolverAllowing_ShouldStillDetectSequentialReuseAsTheft()
+        {
+            FakeRefreshClaimsResolver resolver = AllowReturning(Array.Empty<Claim>(), Array.Empty<string>());
+            RefreshTokenService service = BuildService(resolver);
+
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string familyId = _store.Tokens[RefreshTokenService.HashToken(rawToken)].FamilyId;
+
+            RefreshResult firstResult = await service.RefreshAsync(rawToken, _jwtTokenService);
+            Assert.IsTrue(firstResult.Success);
+
+            RefreshResult secondResult = await service.RefreshAsync(rawToken, _jwtTokenService);
+
+            Assert.IsFalse(secondResult.Success);
+            Assert.AreEqual(RefreshFailureReason.TheftDetected, secondResult.FailureReason);
+
+            foreach (StoredRefreshToken token in _store.Tokens.Values)
+            {
+                if (token.FamilyId == familyId)
+                {
+                    Assert.IsTrue(token.IsInvalidated);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithResolver_ShouldPassStoredClaimsAndRolesOnContext()
+        {
+            FakeRefreshClaimsResolver resolver = AllowReturning(Array.Empty<Claim>(), Array.Empty<string>());
+            RefreshTokenService service = BuildService(resolver);
+
+            string? storedClaims = RefreshTokenService.SerializeClaims(new List<Claim>
+            {
+                new Claim("tenant_id", "tenant-42"),
+                new Claim("email", "test@example.com"),
+            });
+            string? storedRoles = RefreshTokenService.SerializeRoles(new List<string> { "admin", "auditor" });
+
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", storedClaims, storedRoles);
+
+            await service.RefreshAsync(rawToken, _jwtTokenService);
+
+            Assert.AreEqual(1, resolver.Calls.Count);
+            RefreshClaimsContext captured = resolver.Calls[0];
+            Assert.AreEqual(1, captured.StoredClaims.Count(c => c.Type == "tenant_id" && c.Value == "tenant-42"));
+            Assert.AreEqual(1, captured.StoredClaims.Count(c => c.Type == "email" && c.Value == "test@example.com"));
+            CollectionAssert.AreEquivalent(new List<string> { "admin", "auditor" }, captured.StoredRoles.ToList());
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithHttpContextProvided_ShouldPassItToResolver()
+        {
+            FakeRefreshClaimsResolver resolver = AllowReturning(Array.Empty<Claim>(), Array.Empty<string>());
+            RefreshTokenService service = BuildService(resolver);
+
+            HttpContext httpContext = new DefaultHttpContext();
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", null, null);
+
+            RefreshResult result = await service.RefreshAsync(rawToken, _jwtTokenService, httpContext);
+
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(1, resolver.Calls.Count);
+            Assert.AreSame(httpContext, resolver.Calls[0].HttpContext);
+            Assert.AreEqual("user-1", resolver.Calls[0].Subject);
+            Assert.AreEqual("user", resolver.Calls[0].AuthType);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithNullHttpContext_ShouldStillInvokeResolver()
+        {
+            FakeRefreshClaimsResolver resolver = AllowReturning(Array.Empty<Claim>(), Array.Empty<string>());
+            RefreshTokenService service = BuildService(resolver);
+
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", null, null);
+
+            RefreshResult result = await service.RefreshAsync(rawToken, _jwtTokenService);
+
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(1, resolver.Calls.Count);
+            Assert.IsNull(resolver.Calls[0].HttpContext);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithCancellationToken_ShouldPropagateItToResolver()
+        {
+            FakeRefreshClaimsResolver resolver = AllowReturning(Array.Empty<Claim>(), Array.Empty<string>());
+            RefreshTokenService service = BuildService(resolver);
+
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", null, null);
+
+            await service.RefreshAsync(rawToken, _jwtTokenService, httpContext: null, cancellationToken: cts.Token);
+
+            Assert.AreEqual(1, resolver.ReceivedCancellationTokens.Count);
+            Assert.AreEqual(cts.Token, resolver.ReceivedCancellationTokens[0]);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithResolverDenying_ShouldInvokeAuditLoggerWithDeniedByResolverResult()
+        {
+            FakeRefreshClaimsResolver resolver = Denying();
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            RefreshTokenService service = BuildService(resolver, auditLogger);
+
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", null, null);
+
+            await service.RefreshAsync(rawToken, _jwtTokenService);
+
+            Assert.AreEqual(1, auditLogger.RefreshCalls.Count);
+            Assert.IsFalse(auditLogger.RefreshCalls[0].Result.Success);
+            Assert.AreEqual(RefreshFailureReason.DeniedByResolver, auditLogger.RefreshCalls[0].Result.FailureReason);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithResolverThrowing_ShouldNotInvokeAuditLogger()
+        {
+            // Pins the documented contract that resolver throws propagate without burning the
+            // stored token AND without surfacing an audit event. If a future refactor wraps the
+            // resolver in try/finally to "fix" the audit gap, this test catches it.
+            FakeRefreshClaimsResolver resolver = Throwing(new InvalidOperationException("resolver blew up"));
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            RefreshTokenService service = BuildService(resolver, auditLogger);
+
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", null, null);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => service.RefreshAsync(rawToken, _jwtTokenService));
+
+            Assert.AreEqual(0, auditLogger.RefreshCalls.Count);
+        }
+    }
+}

--- a/EasyReasy.Auth.Tests/RefreshTokenServiceClaimsResolverTests.cs
+++ b/EasyReasy.Auth.Tests/RefreshTokenServiceClaimsResolverTests.cs
@@ -215,6 +215,26 @@ namespace EasyReasy.Auth.Tests
         }
 
         [TestMethod]
+        public async Task RefreshAsync_WithResolverThrowing_ShouldPreserveOriginalStackTrace()
+        {
+            // Throws inside the resolver must propagate with the original stack intact, not
+            // wrapped or re-thrown via `throw new …(…)`. A bare `throw;` is the C# idiom for
+            // this; the test pins it so a future refactor that catches and re-throws (or
+            // wraps in another exception type) gets caught.
+            InvalidOperationException injected = new InvalidOperationException("resolver blew up");
+            FakeRefreshClaimsResolver resolver = Throwing(injected);
+            RefreshTokenService service = BuildService(resolver);
+
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", null, null);
+
+            InvalidOperationException thrown = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => service.RefreshAsync(rawToken, _jwtTokenService));
+            Assert.AreSame(injected, thrown);
+            Assert.IsTrue(thrown.StackTrace?.Contains(nameof(FakeRefreshClaimsResolver)) == true,
+                "expected stack trace to retain the resolver frame; got: " + thrown.StackTrace);
+        }
+
+        [TestMethod]
         public async Task RefreshAsync_WithResolverThrowing_ShouldNotConsumeStoredToken()
         {
             FakeRefreshClaimsResolver resolver = Throwing(new InvalidOperationException("resolver blew up"));
@@ -345,21 +365,27 @@ namespace EasyReasy.Auth.Tests
         }
 
         [TestMethod]
-        public async Task RefreshAsync_WithResolverThrowing_ShouldNotInvokeAuditLogger()
+        public async Task RefreshAsync_WithResolverThrowing_ShouldInvokeAuditLoggerWithResolverErrorResult()
         {
-            // Pins the documented contract that resolver throws propagate without burning the
-            // stored token AND without surfacing an audit event. If a future refactor wraps the
-            // resolver in try/finally to "fix" the audit gap, this test catches it.
+            // ISO 27001 A.12.4.1: the audit log must be the authoritative record of every
+            // refresh outcome, including faults. A resolver throw emits a synthetic
+            // ResolverError result BEFORE the exception propagates.
             FakeRefreshClaimsResolver resolver = Throwing(new InvalidOperationException("resolver blew up"));
             RecordingAuditLogger auditLogger = new RecordingAuditLogger();
             RefreshTokenService service = BuildService(resolver, auditLogger);
 
             string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string expectedFamilyId = _store.Tokens[RefreshTokenService.HashToken(rawToken)].FamilyId;
 
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(
                 () => service.RefreshAsync(rawToken, _jwtTokenService));
 
-            Assert.AreEqual(0, auditLogger.RefreshCalls.Count);
+            Assert.AreEqual(1, auditLogger.RefreshCalls.Count);
+            RefreshResult auditedResult = auditLogger.RefreshCalls[0].Result;
+            Assert.IsFalse(auditedResult.Success);
+            Assert.AreEqual(RefreshFailureReason.ResolverError, auditedResult.FailureReason);
+            Assert.AreEqual("user-1", auditedResult.Subject);
+            Assert.AreEqual(expectedFamilyId, auditedResult.FamilyId);
         }
     }
 }

--- a/EasyReasy.Auth/AuthServiceCollectionExtensions.cs
+++ b/EasyReasy.Auth/AuthServiceCollectionExtensions.cs
@@ -97,6 +97,15 @@ namespace EasyReasy.Auth
         /// Registers the refresh token service and its backing store for dependency injection.
         /// The consumer-provided <typeparamref name="TStore"/> is registered as scoped.
         /// </summary>
+        /// <remarks>
+        /// If an <see cref="IAuthAuditLogger"/> is registered in the same service collection,
+        /// the refresh token service picks it up automatically and invokes its hooks on every
+        /// refresh, logout, and bulk session invalidation. If an <see cref="IRefreshClaimsResolver"/>
+        /// is registered, the refresh token service picks it up automatically and invokes it on
+        /// every refresh to either re-evaluate the claims and roles that ride onto the new
+        /// tokens or deny the refresh outright. Both registrations are optional and must be
+        /// added to the service collection before this method is called.
+        /// </remarks>
         /// <typeparam name="TStore">
         /// The consumer's implementation of <see cref="IRefreshTokenStore"/> for persisting refresh tokens.
         /// </typeparam>
@@ -119,7 +128,8 @@ namespace EasyReasy.Auth
             {
                 IRefreshTokenStore store = provider.GetRequiredService<IRefreshTokenStore>();
                 IAuthAuditLogger? auditLogger = provider.GetService<IAuthAuditLogger>();
-                return new RefreshTokenService(store, refreshTokenLifetime, accessTokenLifetime, auditLogger);
+                IRefreshClaimsResolver? claimsResolver = provider.GetService<IRefreshClaimsResolver>();
+                return new RefreshTokenService(store, refreshTokenLifetime, accessTokenLifetime, auditLogger, claimsResolver);
             });
 
             return services;

--- a/EasyReasy.Auth/EasyReasy.Auth.csproj
+++ b/EasyReasy.Auth/EasyReasy.Auth.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <VersionPrefix>4.0.0</VersionPrefix>
+    <VersionPrefix>4.1.0</VersionPrefix>
     <PackageIcon>BaseIcon.png</PackageIcon>
   </PropertyGroup>
 

--- a/EasyReasy.Auth/IRefreshClaimsResolver.cs
+++ b/EasyReasy.Auth/IRefreshClaimsResolver.cs
@@ -1,0 +1,53 @@
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// Optional consumer-supplied hook invoked by <see cref="RefreshTokenService"/> on every
+    /// refresh, after the stored token has been validated but before the atomic consume.
+    /// </summary>
+    /// <remarks>
+    /// When registered in DI, the resolver's decision either allows the refresh to proceed —
+    /// with the resolver's claims and roles in place of the stored ones on both the new access
+    /// token and the newly persisted refresh token — or denies it without burning the stored
+    /// refresh token. Resolver-before-consume ordering ensures that a transient resolver
+    /// failure (deny or throw) cannot cause the legitimate next attempt to trip theft
+    /// detection and revoke the user's entire session family.
+    ///
+    /// When no resolver is registered, refresh behaviour is identical to having no hook at
+    /// all: the stored claims and roles are replayed verbatim onto the new tokens.
+    ///
+    /// Implementations should be resilient to a <see cref="RefreshClaimsContext.HttpContext"/>
+    /// of <c>null</c>, which occurs when <see cref="IRefreshTokenService.RefreshAsync"/> is
+    /// invoked from a non-HTTP caller such as a background job.
+    ///
+    /// Implementations should be fast. The resolver runs inside the read-then-consume window
+    /// of the refresh path, so a slow resolver (for example one that issues a per-refresh
+    /// network call or database round-trip) widens the window in which two near-simultaneous
+    /// legitimate refreshes from the same client can race, with the loser tripping theft
+    /// detection and invalidating the entire token family. Cache hot lookups; avoid expensive
+    /// work on the refresh path.
+    ///
+    /// Resolvers should also avoid side effects on the hot path. The decision returned by the
+    /// resolver is not the final outcome of the refresh: the subsequent atomic consume can
+    /// still fail and return <see cref="RefreshFailureReason.TheftDetected"/>, in which case
+    /// the family is invalidated but anything the resolver already wrote (audit rows, counter
+    /// increments, outbound webhooks) is not rolled back. Any side effect a resolver must
+    /// perform should therefore be idempotent so repeated refresh attempts after a theft
+    /// rejection do not double-emit.
+    /// </remarks>
+    public interface IRefreshClaimsResolver
+    {
+        /// <summary>
+        /// Re-evaluates claims and roles for a refresh request, or denies the refresh.
+        /// </summary>
+        /// <param name="context">The refresh context, including the originally stored claims and roles.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
+        /// <returns>
+        /// A <see cref="RefreshClaimsDecision"/> describing the resolver's verdict. Exceptions
+        /// thrown from this method propagate out of <see cref="IRefreshTokenService.RefreshAsync"/>
+        /// without consuming the stored refresh token, so the client can retry once the
+        /// underlying issue is resolved. Consumers that prefer graceful failure should catch
+        /// internally and return <see cref="RefreshClaimsDecision.Deny"/> instead.
+        /// </returns>
+        Task<RefreshClaimsDecision> ResolveAsync(RefreshClaimsContext context, CancellationToken cancellationToken);
+    }
+}

--- a/EasyReasy.Auth/IRefreshClaimsResolver.cs
+++ b/EasyReasy.Auth/IRefreshClaimsResolver.cs
@@ -45,8 +45,12 @@ namespace EasyReasy.Auth
         /// A <see cref="RefreshClaimsDecision"/> describing the resolver's verdict. Exceptions
         /// thrown from this method propagate out of <see cref="IRefreshTokenService.RefreshAsync"/>
         /// without consuming the stored refresh token, so the client can retry once the
-        /// underlying issue is resolved. Consumers that prefer graceful failure should catch
-        /// internally and return <see cref="RefreshClaimsDecision.Deny"/> instead.
+        /// underlying issue is resolved. Before the exception propagates, a synthetic
+        /// <see cref="RefreshFailureReason.ResolverError"/> result is emitted to
+        /// <see cref="IAuthAuditLogger.OnRefreshAsync"/> so the audit trail remains the
+        /// authoritative record of every refresh outcome (ISO 27001 A.12.4.1). Consumers
+        /// that prefer graceful failure without surfacing an exception should catch internally
+        /// and return <see cref="RefreshClaimsDecision.Deny"/> instead.
         /// </returns>
         Task<RefreshClaimsDecision> ResolveAsync(RefreshClaimsContext context, CancellationToken cancellationToken);
     }

--- a/EasyReasy.Auth/IRefreshTokenService.cs
+++ b/EasyReasy.Auth/IRefreshTokenService.cs
@@ -25,12 +25,19 @@ namespace EasyReasy.Auth
         /// Implements token rotation with theft detection — if a consumed token is reused,
         /// the entire token family is invalidated.
         /// </summary>
+        /// <remarks>
+        /// When an <see cref="IRefreshClaimsResolver"/> is registered, the implementation
+        /// invokes it before the atomic consume to either re-evaluate the claims and roles
+        /// that ride onto the new tokens (replacing what was stored at login time) or deny
+        /// the refresh outright with <see cref="RefreshFailureReason.DeniedByResolver"/>.
+        /// </remarks>
         /// <param name="refreshToken">The raw refresh token from the client.</param>
         /// <param name="jwtTokenService">The JWT token service used to create the new access token.</param>
         /// <param name="httpContext">
         /// The HTTP context of the triggering request, when called from an HTTP endpoint.
-        /// Pass <c>null</c> for programmatic refreshes (e.g. from a background service). Only used to
-        /// propagate context to <see cref="IAuthAuditLogger.OnRefreshAsync"/>.
+        /// Pass <c>null</c> for programmatic refreshes (e.g. from a background service). Used to
+        /// propagate context to both <see cref="IAuthAuditLogger.OnRefreshAsync"/> and
+        /// <see cref="IRefreshClaimsResolver.ResolveAsync"/>.
         /// </param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A <see cref="RefreshResult"/> indicating success or failure.</returns>

--- a/EasyReasy.Auth/README.md
+++ b/EasyReasy.Auth/README.md
@@ -449,6 +449,60 @@ public class MyAuthService : IAuthRequestValidationService
 - If a token that was already used gets presented again, the library detects theft and **invalidates the entire family**
 - Everything is opt-in: you must register the service, enable the endpoint, and inject `IRefreshTokenService` in your validation service
 
+#### Mid-session re-evaluation: `IRefreshClaimsResolver`
+
+By default, the refresh path inherits the claims and roles from the previous token in the family. That works fine for stable sessions, but it does not let policy changes ride into the new access token: a password that expires mid-session, a role that gets revoked, an account that gets disabled — none of these reach the user until they log in again.
+
+Register an `IRefreshClaimsResolver` and the library calls it on every refresh, before the atomic consume. The resolver either returns the claims and roles to put on the new tokens (replacing what was stored) or denies the refresh outright with `RefreshFailureReason.DeniedByResolver`. When no resolver is registered, refresh behaviour is identical to today.
+
+The intended pattern is **re-derive from the current user state on every refresh**, not "take what's stored and patch it." Anything the resolver outputs replaces the stored claims and roles on both the new access token and the new stored refresh row, so any value you want to ride forward must be returned each time.
+
+```csharp
+public class PolicyAwareRefreshResolver : IRefreshClaimsResolver
+{
+    private readonly IUserRepository _users;
+
+    public PolicyAwareRefreshResolver(IUserRepository users) { _users = users; }
+
+    public async Task<RefreshClaimsDecision> ResolveAsync(
+        RefreshClaimsContext context, CancellationToken cancellationToken)
+    {
+        User? user = await _users.GetByIdAsync(context.Subject, cancellationToken);
+        if (user == null || user.IsDisabled)
+        {
+            return RefreshClaimsDecision.Deny();
+        }
+
+        // Build claims fresh from the current user, not from context.StoredClaims —
+        // re-deriving each refresh is the whole point of the resolver. (Use
+        // context.StoredClaims only for facts that genuinely cannot be re-derived.)
+        List<Claim> claims = new List<Claim>
+        {
+            new Claim("tenant_id", user.TenantId),
+            new Claim("email", user.Email),
+        };
+        if (user.PasswordExpiresAt <= DateTime.UtcNow)
+        {
+            claims.Add(new Claim("pwd_expired", "true"));
+        }
+
+        return RefreshClaimsDecision.Allow(claims, user.CurrentRoles);
+    }
+}
+
+// Program.cs — register before AddRefreshTokenService<TStore>
+builder.Services.AddScoped<IRefreshClaimsResolver, PolicyAwareRefreshResolver>();
+builder.Services.AddRefreshTokenService<MyRefreshTokenStore>();
+```
+
+A few contract notes worth knowing:
+
+- **Resolver runs before the atomic consume.** A `Deny()` or a thrown resolver does **not** burn the stored refresh token. The client can retry once the consumer fixes the underlying issue. Theft detection is unchanged — it still fires at the atomic consume on the legitimate winning request.
+- **Throws propagate.** If your resolver fails (DB blip, transient error), the exception bubbles out of `RefreshAsync` and the audit logger is **not** invoked. Consumers that prefer a graceful denial should catch internally and return `RefreshClaimsDecision.Deny()`.
+- **Side effects must be idempotent.** Even on `Allow`, the subsequent atomic consume can still fail (concurrent reuse → `TheftDetected`). Any side effects the resolver already committed will persist.
+- **Keep it fast.** The resolver runs inside the read-then-consume window. A slow resolver widens the race window in which two legitimate near-simultaneous refreshes trip theft detection. Cache hot lookups; avoid per-refresh network calls.
+- **`DeniedByResolver` flows through `IAuthAuditLogger.OnRefreshAsync`** like any other refresh failure — your existing audit pipeline picks it up automatically.
+
 #### Important: `MarkAsConsumedAsync` Must Be Atomic
 
 `MarkAsConsumedAsync` returns `bool` — it must return `true` only for the **first** caller and `false` for any concurrent requests that try to consume the same token. This prevents a race condition where two simultaneous requests both redeem the same refresh token before either marks it consumed.
@@ -520,7 +574,7 @@ Every authentication event the library surfaces — success or failure — is re
 |---|---|---|---|
 | Successful / failed username+password login | `OnLoginAsync(httpContext, LoginResult)` | ISO 27001 A.12.4.1 | outcome, `AttemptedSubject`, `FailureReason`, IP, User-Agent, time |
 | Successful / failed API key auth | `OnApiKeyAuthAsync(httpContext, ApiKeyAuthResult)` | ISO 27001 A.12.4.1 | outcome, `AttemptedClientId`, `FailureReason`, IP, User-Agent, time |
-| Refresh (incl. `TheftDetected`) | `OnRefreshAsync(httpContext, RefreshResult)` | ISO 27001 A.12.4.1 | outcome, `Subject`, `FamilyId`, `FailureReason`, IP, time |
+| Refresh (incl. `TheftDetected` and `DeniedByResolver`) | `OnRefreshAsync(httpContext, RefreshResult)` | ISO 27001 A.12.4.1 | outcome, `Subject`, `FamilyId`, `FailureReason`, IP, time |
 | Logout | `OnLogoutAsync(httpContext, LogoutResult)` | ISO 27001 A.9.2.6 | `WasKnown`, `Subject`, `FamilyId`, IP, time |
 | Bulk session revocation | `OnSessionsInvalidatedAsync(SessionRevocationResult)` | ISO 27001 A.9.2.6 | `Subject`, `InvalidatedFamilyCount`, time |
 
@@ -548,7 +602,9 @@ public class MyAuditLogger : IAuthAuditLogger
 
     public Task OnRefreshAsync(HttpContext? ctx, RefreshResult result)
     {
-        // TheftDetected is particularly worth alerting on.
+        // TheftDetected and DeniedByResolver are particularly worth alerting on —
+        // both can indicate a compromised session or a policy state change (password
+        // expiry, role revocation, account disable) that just blocked a refresh.
         _logger.LogInformation(
             "auth.refresh {Outcome} subject={Subject} family={Family} reason={Reason}",
             result.Success ? "success" : "failure",
@@ -759,6 +815,16 @@ The progressive delay middleware helps protect your API from brute-force attacks
 ---
 
 For more details, see XML comments in the code or explore the source. This library is designed to be easy to use and secure enough for most uses cases by default.
+
+## Migration from 4.0.0
+
+Version 4.1.0 is additive — no breaking changes. Existing callers compile and behave identically. The new capability is one optional DI service: `IRefreshClaimsResolver`, which lets consumers re-evaluate claims and roles on every refresh or deny a refresh outright.
+
+### New: `IRefreshClaimsResolver`
+- **Opt-in DI service.** Register an implementation before `AddRefreshTokenService<TStore>` and the refresh path picks it up automatically. Without a registration, refresh behaviour is identical to 4.0.0 — stored claims and roles are replayed verbatim onto the new tokens.
+- **Use cases.** Mid-session password expiry enforcement (e.g. 21 CFR Part 11 §11.300), mid-session role demotion, mid-session account disable. See Section 8 "Refresh Tokens → Mid-session re-evaluation" for the full contract and an example implementation.
+- **New `RefreshFailureReason.DeniedByResolver`** distinguishes a consumer-driven deny from theft, expiry, or invalidation. It flows through `IAuthAuditLogger.OnRefreshAsync` like every other refresh failure.
+- **No interface or signature changes.** `IRefreshTokenService`, `IRefreshTokenStore`, `RefreshResult`, and the wire format are all unchanged.
 
 ## Migration from 3.x
 

--- a/EasyReasy.Auth/README.md
+++ b/EasyReasy.Auth/README.md
@@ -498,7 +498,7 @@ builder.Services.AddRefreshTokenService<MyRefreshTokenStore>();
 A few contract notes worth knowing:
 
 - **Resolver runs before the atomic consume.** A `Deny()` or a thrown resolver does **not** burn the stored refresh token. The client can retry once the consumer fixes the underlying issue. Theft detection is unchanged — it still fires at the atomic consume on the legitimate winning request.
-- **Throws propagate.** If your resolver fails (DB blip, transient error), the exception bubbles out of `RefreshAsync` and the audit logger is **not** invoked. Consumers that prefer a graceful denial should catch internally and return `RefreshClaimsDecision.Deny()`.
+- **Throws propagate, with an audit row first.** If your resolver fails (DB blip, transient error), the exception bubbles out of `RefreshAsync` — but before it propagates, the audit logger receives a synthetic `RefreshFailureReason.ResolverError` result so the audit trail remains the authoritative record of every refresh outcome (ISO 27001 A.12.4.1). Consumers that prefer a graceful denial without surfacing an exception should catch internally and return `RefreshClaimsDecision.Deny()`.
 - **Side effects must be idempotent.** Even on `Allow`, the subsequent atomic consume can still fail (concurrent reuse → `TheftDetected`). Any side effects the resolver already committed will persist.
 - **Keep it fast.** The resolver runs inside the read-then-consume window. A slow resolver widens the race window in which two legitimate near-simultaneous refreshes trip theft detection. Cache hot lookups; avoid per-refresh network calls.
 - **`DeniedByResolver` flows through `IAuthAuditLogger.OnRefreshAsync`** like any other refresh failure — your existing audit pipeline picks it up automatically.
@@ -574,7 +574,7 @@ Every authentication event the library surfaces — success or failure — is re
 |---|---|---|---|
 | Successful / failed username+password login | `OnLoginAsync(httpContext, LoginResult)` | ISO 27001 A.12.4.1 | outcome, `AttemptedSubject`, `FailureReason`, IP, User-Agent, time |
 | Successful / failed API key auth | `OnApiKeyAuthAsync(httpContext, ApiKeyAuthResult)` | ISO 27001 A.12.4.1 | outcome, `AttemptedClientId`, `FailureReason`, IP, User-Agent, time |
-| Refresh (incl. `TheftDetected` and `DeniedByResolver`) | `OnRefreshAsync(httpContext, RefreshResult)` | ISO 27001 A.12.4.1 | outcome, `Subject`, `FamilyId`, `FailureReason`, IP, time |
+| Refresh (incl. `TheftDetected`, `DeniedByResolver`, `ResolverError`) | `OnRefreshAsync(httpContext, RefreshResult)` | ISO 27001 A.12.4.1 | outcome, `Subject`, `FamilyId`, `FailureReason`, IP, time |
 | Logout | `OnLogoutAsync(httpContext, LogoutResult)` | ISO 27001 A.9.2.6 | `WasKnown`, `Subject`, `FamilyId`, IP, time |
 | Bulk session revocation | `OnSessionsInvalidatedAsync(SessionRevocationResult)` | ISO 27001 A.9.2.6 | `Subject`, `InvalidatedFamilyCount`, time |
 
@@ -824,6 +824,7 @@ Version 4.1.0 is additive — no breaking changes. Existing callers compile and 
 - **Opt-in DI service.** Register an implementation before `AddRefreshTokenService<TStore>` and the refresh path picks it up automatically. Without a registration, refresh behaviour is identical to 4.0.0 — stored claims and roles are replayed verbatim onto the new tokens.
 - **Use cases.** Mid-session password expiry enforcement (e.g. 21 CFR Part 11 §11.300), mid-session role demotion, mid-session account disable. See Section 8 "Refresh Tokens → Mid-session re-evaluation" for the full contract and an example implementation.
 - **New `RefreshFailureReason.DeniedByResolver`** distinguishes a consumer-driven deny from theft, expiry, or invalidation. It flows through `IAuthAuditLogger.OnRefreshAsync` like every other refresh failure.
+- **New `RefreshFailureReason.ResolverError`** is emitted to `IAuthAuditLogger.OnRefreshAsync` when a resolver throws, so the audit trail records every refresh outcome including faults (ISO 27001 A.12.4.1). The original exception still propagates out of `RefreshAsync` with its original stack trace, so consumer exception-handling middleware is unaffected.
 - **No interface or signature changes.** `IRefreshTokenService`, `IRefreshTokenStore`, `RefreshResult`, and the wire format are all unchanged.
 
 ## Migration from 3.x

--- a/EasyReasy.Auth/RefreshClaimsContext.cs
+++ b/EasyReasy.Auth/RefreshClaimsContext.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
+
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// The context supplied to <see cref="IRefreshClaimsResolver.ResolveAsync"/> on every refresh.
+    /// </summary>
+    public sealed class RefreshClaimsContext
+    {
+        /// <summary>
+        /// The subject identifier (user id) the refresh token was originally issued to.
+        /// </summary>
+        public string Subject { get; }
+
+        /// <summary>
+        /// The authentication type the refresh token was originally issued under, e.g. "user" or "apikey".
+        /// </summary>
+        public string AuthType { get; }
+
+        /// <summary>
+        /// The claims persisted on the refresh token row that just validated. Initially the
+        /// claims serialized at login time; if a resolver has previously returned
+        /// <see cref="RefreshClaimsDecision.Allow"/>, the claims that resolver supplied on the
+        /// most recent refresh in this family.
+        /// </summary>
+        public IReadOnlyList<Claim> StoredClaims { get; }
+
+        /// <summary>
+        /// The roles persisted on the refresh token row that just validated. Initially the
+        /// roles serialized at login time; if a resolver has previously returned
+        /// <see cref="RefreshClaimsDecision.Allow"/>, the roles that resolver supplied on the
+        /// most recent refresh in this family.
+        /// </summary>
+        public IReadOnlyList<string> StoredRoles { get; }
+
+        /// <summary>
+        /// The HTTP context for the refresh request, or <c>null</c> when
+        /// <see cref="IRefreshTokenService.RefreshAsync"/> is invoked outside an HTTP request
+        /// (for example from a background job). Resolvers must tolerate <c>null</c>.
+        /// </summary>
+        public HttpContext? HttpContext { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefreshClaimsContext"/> class.
+        /// </summary>
+        /// <param name="subject">The subject identifier the refresh token was issued to.</param>
+        /// <param name="authType">The authentication type the refresh token was issued under.</param>
+        /// <param name="storedClaims">The claims that were originally serialized at login time.</param>
+        /// <param name="storedRoles">The roles that were originally serialized at login time.</param>
+        /// <param name="httpContext">The HTTP context for the refresh request, or <c>null</c> for non-HTTP callers.</param>
+        public RefreshClaimsContext(
+            string subject,
+            string authType,
+            IReadOnlyList<Claim> storedClaims,
+            IReadOnlyList<string> storedRoles,
+            HttpContext? httpContext)
+        {
+            ArgumentNullException.ThrowIfNull(subject);
+            ArgumentNullException.ThrowIfNull(authType);
+            ArgumentNullException.ThrowIfNull(storedClaims);
+            ArgumentNullException.ThrowIfNull(storedRoles);
+
+            Subject = subject;
+            AuthType = authType;
+            StoredClaims = storedClaims;
+            StoredRoles = storedRoles;
+            HttpContext = httpContext;
+        }
+    }
+}

--- a/EasyReasy.Auth/RefreshClaimsDecision.cs
+++ b/EasyReasy.Auth/RefreshClaimsDecision.cs
@@ -1,0 +1,63 @@
+using System.Security.Claims;
+
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// The verdict returned by <see cref="IRefreshClaimsResolver.ResolveAsync"/>.
+    /// Construct via the static factory methods <see cref="Allow"/> and <see cref="Deny"/>.
+    /// </summary>
+    public sealed class RefreshClaimsDecision
+    {
+        /// <summary>
+        /// Whether the resolver denied the refresh outright. When <c>true</c>,
+        /// <see cref="Claims"/> and <see cref="Roles"/> are empty and
+        /// <see cref="RefreshTokenService"/> returns
+        /// <see cref="RefreshFailureReason.DeniedByResolver"/> without consuming the stored
+        /// refresh token.
+        /// </summary>
+        public bool IsDenied { get; }
+
+        /// <summary>
+        /// The claims to place on the new access token and the new stored refresh token when
+        /// the refresh is allowed. Empty when the refresh is denied.
+        /// </summary>
+        public IReadOnlyList<Claim> Claims { get; }
+
+        /// <summary>
+        /// The roles to place on the new access token and the new stored refresh token when
+        /// the refresh is allowed. Empty when the refresh is denied.
+        /// </summary>
+        public IReadOnlyList<string> Roles { get; }
+
+        private RefreshClaimsDecision(bool isDenied, IReadOnlyList<Claim> claims, IReadOnlyList<string> roles)
+        {
+            IsDenied = isDenied;
+            Claims = claims;
+            Roles = roles;
+        }
+
+        /// <summary>
+        /// Creates a decision that allows the refresh to proceed with the supplied claims and roles,
+        /// replacing what was originally stored at login time.
+        /// </summary>
+        /// <param name="claims">The claims to place on the new access token and the new stored refresh token.</param>
+        /// <param name="roles">The roles to place on the new access token and the new stored refresh token.</param>
+        /// <returns>An allow-decision carrying the supplied claims and roles.</returns>
+        public static RefreshClaimsDecision Allow(IEnumerable<Claim> claims, IEnumerable<string> roles)
+        {
+            ArgumentNullException.ThrowIfNull(claims);
+            ArgumentNullException.ThrowIfNull(roles);
+            return new RefreshClaimsDecision(false, claims.ToList(), roles.ToList());
+        }
+
+        /// <summary>
+        /// Creates a decision that denies the refresh. The stored refresh token is not consumed,
+        /// so a subsequent legitimate refresh attempt is not affected.
+        /// </summary>
+        /// <returns>A deny-decision.</returns>
+        public static RefreshClaimsDecision Deny()
+        {
+            return new RefreshClaimsDecision(true, Array.Empty<Claim>(), Array.Empty<string>());
+        }
+    }
+}

--- a/EasyReasy.Auth/RefreshFailureReason.cs
+++ b/EasyReasy.Auth/RefreshFailureReason.cs
@@ -24,6 +24,15 @@ namespace EasyReasy.Auth
         /// The refresh token has already been consumed, indicating potential token theft.
         /// The entire token family has been invalidated as a security measure.
         /// </summary>
-        TheftDetected
+        TheftDetected,
+
+        /// <summary>
+        /// The consumer-supplied <see cref="IRefreshClaimsResolver"/> denied the refresh
+        /// (for example because the user's password has expired, the account has been
+        /// disabled, or the role required for the session was revoked). The stored refresh
+        /// token is not consumed, so a subsequent legitimate refresh after the deny condition
+        /// clears is not affected.
+        /// </summary>
+        DeniedByResolver
     }
 }

--- a/EasyReasy.Auth/RefreshFailureReason.cs
+++ b/EasyReasy.Auth/RefreshFailureReason.cs
@@ -33,6 +33,16 @@ namespace EasyReasy.Auth
         /// token is not consumed, so a subsequent legitimate refresh after the deny condition
         /// clears is not affected.
         /// </summary>
-        DeniedByResolver
+        DeniedByResolver,
+
+        /// <summary>
+        /// The consumer-supplied <see cref="IRefreshClaimsResolver"/> threw an exception.
+        /// The stored refresh token is not consumed, so the client can retry once the
+        /// underlying issue is resolved. Emitted to <see cref="IAuthAuditLogger.OnRefreshAsync"/>
+        /// so the audit trail records every refresh outcome, including faults (ISO 27001
+        /// A.12.4.1). The original exception still propagates out of
+        /// <see cref="IRefreshTokenService.RefreshAsync"/>.
+        /// </summary>
+        ResolverError
     }
 }

--- a/EasyReasy.Auth/RefreshTokenService.cs
+++ b/EasyReasy.Auth/RefreshTokenService.cs
@@ -16,6 +16,7 @@ namespace EasyReasy.Auth
         private readonly TimeSpan _refreshTokenLifetime;
         private readonly TimeSpan _accessTokenLifetime;
         private readonly IAuthAuditLogger? _auditLogger;
+        private readonly IRefreshClaimsResolver? _claimsResolver;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RefreshTokenService"/> class.
@@ -35,16 +36,24 @@ namespace EasyReasy.Auth
         /// so consumers can emit ISO 27001 A.12.4.1 / A.9.2.6 audit records for both HTTP-driven and programmatic flows.
         /// Lifetime must be at least as long as this service — see <see cref="IAuthAuditLogger"/> remarks.
         /// </param>
+        /// <param name="claimsResolver">
+        /// Optional consumer-supplied claims/roles resolver. When supplied, this service invokes the
+        /// resolver on every refresh — before the atomic consume — to either re-evaluate the claims
+        /// and roles that ride onto the new tokens (replacing what was originally stored at login
+        /// time) or deny the refresh outright. See <see cref="IRefreshClaimsResolver"/>.
+        /// </param>
         public RefreshTokenService(
             IRefreshTokenStore store,
             TimeSpan? refreshTokenLifetime = null,
             TimeSpan? accessTokenLifetime = null,
-            IAuthAuditLogger? auditLogger = null)
+            IAuthAuditLogger? auditLogger = null,
+            IRefreshClaimsResolver? claimsResolver = null)
         {
             _store = store ?? throw new ArgumentNullException(nameof(store));
             _refreshTokenLifetime = refreshTokenLifetime ?? TimeSpan.FromDays(30);
             _accessTokenLifetime = accessTokenLifetime ?? TimeSpan.FromHours(1);
             _auditLogger = auditLogger;
+            _claimsResolver = claimsResolver;
         }
 
         /// <inheritdoc />
@@ -80,7 +89,7 @@ namespace EasyReasy.Auth
         /// <inheritdoc />
         public async Task<RefreshResult> RefreshAsync(string refreshToken, IJwtTokenService jwtTokenService, HttpContext? httpContext = null, CancellationToken cancellationToken = default)
         {
-            RefreshResult result = await ComputeRefreshAsync(refreshToken, jwtTokenService, cancellationToken);
+            RefreshResult result = await ComputeRefreshAsync(refreshToken, jwtTokenService, httpContext, cancellationToken);
 
             if (_auditLogger != null)
             {
@@ -90,48 +99,69 @@ namespace EasyReasy.Auth
             return result;
         }
 
-        private async Task<RefreshResult> ComputeRefreshAsync(string refreshToken, IJwtTokenService jwtTokenService, CancellationToken cancellationToken)
+        private async Task<RefreshResult> ComputeRefreshAsync(string refreshToken, IJwtTokenService jwtTokenService, HttpContext? httpContext, CancellationToken cancellationToken)
         {
             DateTime now = DateTime.UtcNow;
             string tokenHash = HashToken(refreshToken);
             StoredRefreshToken? storedToken = await _store.GetByTokenHashAsync(tokenHash, cancellationToken);
 
-            // Step 1: Token not found
             if (storedToken == null)
             {
                 return RefreshResult.Failed(RefreshFailureReason.TokenNotFound);
             }
 
-            // Step 2: Token invalidated
             if (storedToken.IsInvalidated)
             {
                 return RefreshResult.Failed(RefreshFailureReason.TokenInvalidated, storedToken.Subject, storedToken.FamilyId);
             }
 
-            // Step 3: Token already consumed — theft detected
+            // Token was already consumed — theft detected.
             if (storedToken.ConsumedAt != null)
             {
                 await _store.InvalidateFamilyAsync(storedToken.FamilyId, cancellationToken);
                 return RefreshResult.Failed(RefreshFailureReason.TheftDetected, storedToken.Subject, storedToken.FamilyId);
             }
 
-            // Step 4: Token expired
             if (storedToken.ExpiresAt <= now)
             {
                 return RefreshResult.Failed(RefreshFailureReason.TokenExpired, storedToken.Subject, storedToken.FamilyId);
             }
 
-            // Step 5: Atomically mark old token as consumed — if another request already consumed it, treat as theft
+            // Deserialize once — both the no-resolver branch and the resolver-input branch need these.
+            IReadOnlyList<Claim> claims = DeserializeClaims(storedToken.SerializedClaims);
+            IReadOnlyList<string> roles = DeserializeRoles(storedToken.SerializedRoles);
+
+            // Invoke the consumer-supplied resolver, if registered. This runs BEFORE the atomic
+            // consume so that a deny or a thrown resolver does not burn the stored refresh
+            // token — a transient failure would otherwise trip theft detection on the legitimate
+            // retry and invalidate the entire session family.
+            if (_claimsResolver != null)
+            {
+                RefreshClaimsContext context = new RefreshClaimsContext(
+                    storedToken.Subject,
+                    storedToken.AuthType,
+                    claims,
+                    roles,
+                    httpContext);
+
+                RefreshClaimsDecision decision = await _claimsResolver.ResolveAsync(context, cancellationToken);
+
+                if (decision.IsDenied)
+                {
+                    return RefreshResult.Failed(RefreshFailureReason.DeniedByResolver, storedToken.Subject, storedToken.FamilyId);
+                }
+
+                claims = decision.Claims;
+                roles = decision.Roles;
+            }
+
+            // Atomically mark old token as consumed — if another request already consumed it, treat as theft.
             bool consumed = await _store.MarkAsConsumedAsync(tokenHash, now, cancellationToken);
             if (!consumed)
             {
                 await _store.InvalidateFamilyAsync(storedToken.FamilyId, cancellationToken);
                 return RefreshResult.Failed(RefreshFailureReason.TheftDetected, storedToken.Subject, storedToken.FamilyId);
             }
-
-            // Step 6: Deserialize stored claims and roles, create new access token
-            List<Claim> claims = DeserializeClaims(storedToken.SerializedClaims);
-            List<string> roles = DeserializeRoles(storedToken.SerializedRoles);
 
             DateTime accessTokenExpiresAt = now.Add(_accessTokenLifetime);
             string accessToken = jwtTokenService.CreateToken(
@@ -141,9 +171,14 @@ namespace EasyReasy.Auth
                 roles,
                 accessTokenExpiresAt);
 
-            // Step 7: Generate new refresh token in same family
+            // When the resolver ran, the new row persists the resolved claims/roles so subsequent
+            // refreshes start from there; when no resolver is registered, the original serialized
+            // JSON is reused verbatim.
             string newRawToken = GenerateToken();
             string newTokenHash = HashToken(newRawToken);
+
+            string? newSerializedClaims = _claimsResolver != null ? SerializeClaims(claims) : storedToken.SerializedClaims;
+            string? newSerializedRoles = _claimsResolver != null ? SerializeRoles(roles) : storedToken.SerializedRoles;
 
             StoredRefreshToken newStoredToken = new StoredRefreshToken
             {
@@ -153,13 +188,12 @@ namespace EasyReasy.Auth
                 FamilyId = storedToken.FamilyId,
                 CreatedAt = now,
                 ExpiresAt = now.Add(_refreshTokenLifetime),
-                SerializedClaims = storedToken.SerializedClaims,
-                SerializedRoles = storedToken.SerializedRoles
+                SerializedClaims = newSerializedClaims,
+                SerializedRoles = newSerializedRoles,
             };
 
             await _store.StoreAsync(newStoredToken, cancellationToken);
 
-            // Step 8: Return success with new token pair
             AuthResponse authResponse = new AuthResponse(
                 accessToken,
                 accessTokenExpiresAt.ToString("O"),

--- a/EasyReasy.Auth/RefreshTokenService.cs
+++ b/EasyReasy.Auth/RefreshTokenService.cs
@@ -89,7 +89,19 @@ namespace EasyReasy.Auth
         /// <inheritdoc />
         public async Task<RefreshResult> RefreshAsync(string refreshToken, IJwtTokenService jwtTokenService, HttpContext? httpContext = null, CancellationToken cancellationToken = default)
         {
-            RefreshResult result = await ComputeRefreshAsync(refreshToken, jwtTokenService, httpContext, cancellationToken);
+            RefreshResult result;
+            try
+            {
+                result = await ComputeRefreshAsync(refreshToken, jwtTokenService, httpContext, cancellationToken);
+            }
+            catch
+            {
+                // The audit trail must record every refresh outcome including resolver faults
+                // (ISO 27001 A.12.4.1). Emit a synthetic ResolverError result, then rethrow so
+                // the original exception still propagates with its original stack trace.
+                await TryLogResolverFaultAsync(refreshToken, httpContext, cancellationToken);
+                throw;
+            }
 
             if (_auditLogger != null)
             {
@@ -97,6 +109,36 @@ namespace EasyReasy.Auth
             }
 
             return result;
+        }
+
+        private async Task TryLogResolverFaultAsync(string refreshToken, HttpContext? httpContext, CancellationToken cancellationToken)
+        {
+            if (_auditLogger == null)
+            {
+                return;
+            }
+
+            // Best-effort: a fault here must never replace the original exception. If the
+            // store lookup or the logger itself throws, swallow and fall through to the
+            // outer rethrow so the consumer still sees the resolver's exception.
+            try
+            {
+                string? subject = null;
+                string? familyId = null;
+                StoredRefreshToken? storedToken = await _store.GetByTokenHashAsync(HashToken(refreshToken), cancellationToken);
+                if (storedToken != null)
+                {
+                    subject = storedToken.Subject;
+                    familyId = storedToken.FamilyId;
+                }
+
+                RefreshResult faultResult = RefreshResult.Failed(RefreshFailureReason.ResolverError, subject, familyId);
+                await _auditLogger.OnRefreshAsync(httpContext, faultResult);
+            }
+            catch
+            {
+                // Intentionally swallowed — the outer catch's rethrow is the source of truth.
+            }
         }
 
         private async Task<RefreshResult> ComputeRefreshAsync(string refreshToken, IJwtTokenService jwtTokenService, HttpContext? httpContext, CancellationToken cancellationToken)


### PR DESCRIPTION
## Why?
Closes #9.

The refresh path used to be a closed system — `RefreshTokenService.RefreshAsync` replayed the claims/roles JSON that was serialized at login time, with no way for consumers to intervene. That meant mid-session policy changes (password expiry, role demotion, account disable) couldn't ride through a refresh. The trigger was a 21 CFR Part 11 §11.300 password-aging compliance need.

## What?
Adds a new optional `IRefreshClaimsResolver` DI hook. When registered, `RefreshTokenService` invokes it on every refresh — before the atomic consume — and either uses its returned claims/roles in place of the stored ones (on both the new access token and the new stored refresh row) or denies the refresh outright via the new `RefreshFailureReason.DeniedByResolver`. When no resolver is registered, behavior is byte-for-byte identical to today.

- Three new public types (`IRefreshClaimsResolver`, `RefreshClaimsContext`, `RefreshClaimsDecision`)
- New `RefreshFailureReason.DeniedByResolver`
- DI auto-pickup in `AddRefreshTokenService<TStore>` alongside the existing `IAuthAuditLogger` pickup
- `DeniedByResolver` flows through `IAuthAuditLogger.OnRefreshAsync` like other refresh failures
- Version bumped to `4.1.0` (additive minor)
- 20 new MSTest cases in a dedicated `RefreshTokenServiceClaimsResolverTests.cs` file
- README: new "Mid-session re-evaluation" sub-section under Refresh Tokens, a "Migration from 4.0.0" block, and audit-event table updates

## Challenges
The placement of the resolver call was load-bearing. The intuitive "after the atomic consume" position creates a footgun: a transient resolver failure (DB blip, throw) would burn the stored refresh token, and the legitimate retry would then trip theft detection and invalidate the entire family. A single hiccup becomes "all sessions revoked."

Running the resolver before the atomic consume avoids that entirely. A deny or a throw leaves the stored token untouched, so the client can retry safely. Theft detection is unchanged — it still fires at the atomic consume on the legitimate winning refresh. A new test pins this property explicitly so a future refactor that reorders the steps gets caught.

Throws also propagate (and do NOT trigger the audit logger) by design — the contract is that consumers who want graceful failure return `Deny()` themselves. Both the no-consume-on-throw and the no-audit-on-throw invariants are tested directly.