### PR TITLE
Add targeted refresh-token family retirement to EasyReasy.Auth

### DIFF
--- a/EasyReasy.Auth.Tests/FakeRefreshTokenStore.cs
+++ b/EasyReasy.Auth.Tests/FakeRefreshTokenStore.cs
@@ -6,6 +6,7 @@ namespace EasyReasy.Auth.Tests
     public class FakeRefreshTokenStore : IRefreshTokenStore
     {
         private readonly Dictionary<string, StoredRefreshToken> _tokens = new Dictionary<string, StoredRefreshToken>();
+        private readonly List<string> _invalidatedFamilyIds = new List<string>();
 
         public Task StoreAsync(StoredRefreshToken refreshToken, CancellationToken cancellationToken = default)
         {
@@ -36,6 +37,7 @@ namespace EasyReasy.Auth.Tests
 
         public Task InvalidateFamilyAsync(string familyId, CancellationToken cancellationToken = default)
         {
+            _invalidatedFamilyIds.Add(familyId);
             foreach (StoredRefreshToken token in _tokens.Values)
             {
                 if (token.FamilyId == familyId)
@@ -64,5 +66,11 @@ namespace EasyReasy.Auth.Tests
         /// Gets all stored tokens for test inspection.
         /// </summary>
         public IReadOnlyDictionary<string, StoredRefreshToken> Tokens => _tokens;
+
+        /// <summary>
+        /// Records every family id passed to <see cref="InvalidateFamilyAsync"/>, in call order, so tests can
+        /// assert exactly which families were retired and how many times.
+        /// </summary>
+        public IReadOnlyList<string> InvalidatedFamilyIds => _invalidatedFamilyIds;
     }
 }

--- a/EasyReasy.Auth.Tests/HttpContextExtensionsTests.cs
+++ b/EasyReasy.Auth.Tests/HttpContextExtensionsTests.cs
@@ -44,6 +44,7 @@ namespace EasyReasy.Auth.Tests
                 new Claim("tenant_id", "tenant-42"),
                 new Claim(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Email, "user@example.com"),
                 new Claim("auth_type", "apikey"),
+                new Claim("family_id", "family-7"),
             };
             ClaimsIdentity identity = new ClaimsIdentity(claims, authenticationType: "TestAuth");
             ClaimsPrincipal principal = new ClaimsPrincipal(identity);
@@ -59,6 +60,7 @@ namespace EasyReasy.Auth.Tests
             Assert.AreEqual("user@example.com", context.GetClaimValue(EasyReasyClaim.Email));
             Assert.AreEqual("apikey", context.GetClaimValue(EasyReasyClaim.AuthType));
             Assert.AreEqual("issuer-xyz", context.GetClaimValue(EasyReasyClaim.Issuer));
+            Assert.AreEqual("family-7", context.GetClaimValue(EasyReasyClaim.RefreshFamilyId));
         }
 
         [TestMethod]
@@ -73,6 +75,28 @@ namespace EasyReasy.Auth.Tests
             Assert.IsNull(context.GetClaimValue(EasyReasyClaim.Email));
             Assert.IsNull(context.GetClaimValue(EasyReasyClaim.AuthType));
             Assert.IsNull(context.GetClaimValue(EasyReasyClaim.Issuer));
+            Assert.IsNull(context.GetClaimValue(EasyReasyClaim.RefreshFamilyId));
+        }
+
+        [TestMethod]
+        public void GetRefreshFamilyId_ReturnsClaimValue_WhenPresent()
+        {
+            List<Claim> claims = new List<Claim> { new Claim("family_id", "family-7") };
+            ClaimsIdentity identity = new ClaimsIdentity(claims, authenticationType: "TestAuth");
+            ClaimsPrincipal principal = new ClaimsPrincipal(identity);
+            DefaultHttpContext context = new DefaultHttpContext { User = principal };
+
+            Assert.AreEqual("family-7", context.GetRefreshFamilyId());
+        }
+
+        [TestMethod]
+        public void GetRefreshFamilyId_ReturnsNull_WhenAbsent()
+        {
+            ClaimsIdentity identity = new ClaimsIdentity(); // Not authenticated, no claims
+            ClaimsPrincipal principal = new ClaimsPrincipal(identity);
+            DefaultHttpContext context = new DefaultHttpContext { User = principal };
+
+            Assert.IsNull(context.GetRefreshFamilyId());
         }
     }
 }

--- a/EasyReasy.Auth.Tests/RecordingAuditLogger.cs
+++ b/EasyReasy.Auth.Tests/RecordingAuditLogger.cs
@@ -14,6 +14,7 @@ namespace EasyReasy.Auth.Tests
         public List<(HttpContext? HttpContext, LogoutResult Result)> LogoutCalls { get; } = new List<(HttpContext?, LogoutResult)>();
         public List<SessionRevocationResult> SessionsInvalidatedCalls { get; } = new List<SessionRevocationResult>();
         public List<SessionRevocationResult> ConcurrentSessionsRevokedCalls { get; } = new List<SessionRevocationResult>();
+        public List<(HttpContext? HttpContext, FamilyRetirementResult Result)> SessionSupersededCalls { get; } = new List<(HttpContext?, FamilyRetirementResult)>();
 
         public Task OnLoginAsync(HttpContext httpContext, LoginResult result)
         {
@@ -48,6 +49,12 @@ namespace EasyReasy.Auth.Tests
         public Task OnConcurrentSessionsRevokedAsync(SessionRevocationResult result)
         {
             ConcurrentSessionsRevokedCalls.Add(result);
+            return Task.CompletedTask;
+        }
+
+        public Task OnSessionSupersededAsync(HttpContext? httpContext, FamilyRetirementResult result)
+        {
+            SessionSupersededCalls.Add((httpContext, result));
             return Task.CompletedTask;
         }
     }

--- a/EasyReasy.Auth.Tests/RefreshTokenServiceTests.cs
+++ b/EasyReasy.Auth.Tests/RefreshTokenServiceTests.cs
@@ -1,3 +1,4 @@
+using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 
 namespace EasyReasy.Auth.Tests
@@ -18,6 +19,11 @@ namespace EasyReasy.Auth.Tests
             _store = new FakeRefreshTokenStore();
             _service = new RefreshTokenService(_store);
             _jwtTokenService = new JwtTokenService(TestSecret, TestIssuer);
+        }
+
+        private static IEnumerable<Claim> DecodeClaims(string accessToken)
+        {
+            return new JwtSecurityTokenHandler().ReadJwtToken(accessToken).Claims;
         }
 
         [TestMethod]
@@ -663,6 +669,172 @@ namespace EasyReasy.Auth.Tests
             Assert.AreEqual(1, auditLogger.LogoutCalls.Count);
             Assert.IsFalse(result.WasKnown);
             Assert.IsFalse(auditLogger.LogoutCalls[0].Result.WasKnown);
+        }
+
+        [TestMethod]
+        public async Task CreateRefreshTokenWithFamilyAsync_ReturnsFamilyIdMatchingStoredToken()
+        {
+            RefreshTokenCreationResult result = await _service.CreateRefreshTokenWithFamilyAsync("user-1", "user", null, null);
+
+            string hash = RefreshTokenService.HashToken(result.RawToken);
+            Assert.IsTrue(_store.Tokens.ContainsKey(hash), "the returned raw token should hash to a stored entry");
+            Assert.AreEqual(_store.Tokens[hash].FamilyId, result.FamilyId);
+        }
+
+        [TestMethod]
+        public async Task CreateRefreshTokenAsync_ReturnsRawTokenFromSharedCreationPath()
+        {
+            string rawToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+
+            // The store is keyed by HashToken(rawToken), so a hit proves the legacy method returned the raw
+            // token itself (not the hash or the family id, neither of which would hash to this key).
+            string hash = RefreshTokenService.HashToken(rawToken);
+            Assert.IsTrue(_store.Tokens.ContainsKey(hash), "the legacy method must return the raw token");
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_AfterRefresh_AccessTokenCarriesSingleFamilyIdClaimEqualToFamilyId()
+        {
+            string rawToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string familyId = _store.Tokens[RefreshTokenService.HashToken(rawToken)].FamilyId;
+
+            RefreshResult result = await _service.RefreshAsync(rawToken, _jwtTokenService);
+
+            Assert.IsTrue(result.Success);
+            List<Claim> issued = DecodeClaims(result.AuthResponse!.Token).ToList();
+            Assert.AreEqual(1, issued.Count(c => c.Type == "family_id"));
+            Assert.AreEqual(familyId, issued.Single(c => c.Type == "family_id").Value);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_AcrossRotation_FamilyIdClaimUnchanged()
+        {
+            string rawToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string familyId = _store.Tokens[RefreshTokenService.HashToken(rawToken)].FamilyId;
+
+            RefreshResult first = await _service.RefreshAsync(rawToken, _jwtTokenService);
+            RefreshResult second = await _service.RefreshAsync(first.NewRefreshToken!, _jwtTokenService);
+
+            string firstFamily = DecodeClaims(first.AuthResponse!.Token).Single(c => c.Type == "family_id").Value;
+            string secondFamily = DecodeClaims(second.AuthResponse!.Token).Single(c => c.Type == "family_id").Value;
+            Assert.AreEqual(familyId, firstFamily);
+            Assert.AreEqual(familyId, secondFamily);
+        }
+
+        [TestMethod]
+        public async Task RefreshAsync_WithSpoofedFamilyIdInStoredClaims_OverwritesWithAuthoritativeValue()
+        {
+            string? spoofedClaims = RefreshTokenClaims.SerializeClaims(new List<Claim> { new Claim("family_id", "attacker-supplied") });
+            string rawToken = await _service.CreateRefreshTokenAsync("user-1", "user", spoofedClaims, null);
+            string familyId = _store.Tokens[RefreshTokenService.HashToken(rawToken)].FamilyId;
+
+            RefreshResult result = await _service.RefreshAsync(rawToken, _jwtTokenService);
+
+            List<Claim> issued = DecodeClaims(result.AuthResponse!.Token).ToList();
+            Assert.AreEqual(1, issued.Count(c => c.Type == "family_id"), "the spoofed claim must not be duplicated");
+            Assert.AreEqual(familyId, issued.Single(c => c.Type == "family_id").Value);
+            Assert.AreEqual(0, issued.Count(c => c.Type == "family_id" && c.Value == "attacker-supplied"));
+        }
+
+        [TestMethod]
+        public async Task RetireFamilyAsync_WithFamilyId_InvalidatesThatFamilyOnceAndFiresSupersededNotLogout()
+        {
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            RefreshTokenService service = new RefreshTokenService(_store, auditLogger: auditLogger);
+
+            string rawToken = await service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string familyId = _store.Tokens[RefreshTokenService.HashToken(rawToken)].FamilyId;
+
+            await service.RetireFamilyAsync(familyId, "user-1");
+
+            Assert.IsTrue(_store.Tokens[RefreshTokenService.HashToken(rawToken)].IsInvalidated);
+            Assert.AreEqual(1, _store.InvalidatedFamilyIds.Count(id => id == familyId), "InvalidateFamilyAsync should be called exactly once for the family");
+            Assert.AreEqual(0, auditLogger.LogoutCalls.Count, "a supersession must not be recorded as a logout");
+            Assert.AreEqual(1, auditLogger.SessionSupersededCalls.Count);
+            Assert.AreEqual(familyId, auditLogger.SessionSupersededCalls[0].Result.FamilyId);
+            Assert.AreEqual("user-1", auditLogger.SessionSupersededCalls[0].Result.Subject);
+        }
+
+        [TestMethod]
+        public async Task RetireFamilyAsync_LeavesOtherFamiliesLive()
+        {
+            string priorToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string otherDeviceToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string otherUserToken = await _service.CreateRefreshTokenAsync("user-2", "user", null, null);
+
+            string priorFamilyId = _store.Tokens[RefreshTokenService.HashToken(priorToken)].FamilyId;
+
+            await _service.RetireFamilyAsync(priorFamilyId, "user-1");
+
+            Assert.IsTrue(_store.Tokens[RefreshTokenService.HashToken(priorToken)].IsInvalidated);
+            Assert.IsFalse(_store.Tokens[RefreshTokenService.HashToken(otherDeviceToken)].IsInvalidated, "the subject's other device must stay live");
+            Assert.IsFalse(_store.Tokens[RefreshTokenService.HashToken(otherUserToken)].IsInvalidated, "another subject must stay live");
+        }
+
+        [TestMethod]
+        public async Task RetireFamilyAsync_WithoutAuditLogger_StillInvalidatesFamily()
+        {
+            // The default _service has no audit logger — the hook block must be skipped, not throw.
+            string rawToken = await _service.CreateRefreshTokenAsync("user-1", "user", null, null);
+            string familyId = _store.Tokens[RefreshTokenService.HashToken(rawToken)].FamilyId;
+
+            await _service.RetireFamilyAsync(familyId, "user-1");
+
+            Assert.IsTrue(_store.Tokens[RefreshTokenService.HashToken(rawToken)].IsInvalidated);
+        }
+
+        [TestMethod]
+        public async Task RetireFamilyAsync_WithNonExistentFamilyId_StillCallsStoreAndFiresSuperseded()
+        {
+            // A non-empty family id always acts: the store can't report whether the family existed, so the
+            // contract is "a retire was requested for this family" — InvalidateFamilyAsync is called and the
+            // hook fires even when nothing matches, without throwing.
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            RefreshTokenService service = new RefreshTokenService(_store, auditLogger: auditLogger);
+
+            await service.RetireFamilyAsync("no-such-family", "user-1");
+
+            Assert.AreEqual(1, _store.InvalidatedFamilyIds.Count(id => id == "no-such-family"));
+            Assert.AreEqual(1, auditLogger.SessionSupersededCalls.Count);
+            Assert.AreEqual("no-such-family", auditLogger.SessionSupersededCalls[0].Result.FamilyId);
+            Assert.AreEqual("user-1", auditLogger.SessionSupersededCalls[0].Result.Subject);
+        }
+
+        [TestMethod]
+        public async Task RetireFamilyAsync_WithNullFamilyId_IsNoOp()
+        {
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            RefreshTokenService service = new RefreshTokenService(_store, auditLogger: auditLogger);
+            await service.CreateRefreshTokenAsync("user-1", "user", null, null);
+
+            await service.RetireFamilyAsync(null, "user-1");
+
+            Assert.AreEqual(0, _store.InvalidatedFamilyIds.Count);
+            Assert.AreEqual(0, auditLogger.SessionSupersededCalls.Count);
+        }
+
+        [TestMethod]
+        public async Task RetireFamilyAsync_WithEmptyFamilyId_IsNoOp()
+        {
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            RefreshTokenService service = new RefreshTokenService(_store, auditLogger: auditLogger);
+
+            await service.RetireFamilyAsync(string.Empty);
+
+            Assert.AreEqual(0, _store.InvalidatedFamilyIds.Count);
+            Assert.AreEqual(0, auditLogger.SessionSupersededCalls.Count);
+        }
+
+        [TestMethod]
+        public async Task RetireFamilyAsync_WithWhitespaceFamilyId_IsNoOp()
+        {
+            RecordingAuditLogger auditLogger = new RecordingAuditLogger();
+            RefreshTokenService service = new RefreshTokenService(_store, auditLogger: auditLogger);
+
+            await service.RetireFamilyAsync("   ");
+
+            Assert.AreEqual(0, _store.InvalidatedFamilyIds.Count);
+            Assert.AreEqual(0, auditLogger.SessionSupersededCalls.Count);
         }
     }
 }

--- a/EasyReasy.Auth/EasyReasy.Auth.csproj
+++ b/EasyReasy.Auth/EasyReasy.Auth.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <VersionPrefix>5.1.0</VersionPrefix>
+    <VersionPrefix>5.2.0</VersionPrefix>
     <PackageIcon>BaseIcon.png</PackageIcon>
   </PropertyGroup>
 

--- a/EasyReasy.Auth/EasyReasyClaim.cs
+++ b/EasyReasy.Auth/EasyReasyClaim.cs
@@ -29,5 +29,13 @@ namespace EasyReasy.Auth
         /// Issuer claim.
         /// </summary>
         Issuer,
+
+        /// <summary>
+        /// Refresh token family id claim (claim type <c>"family_id"</c>). This is the client's own opaque
+        /// session identifier: it is intentionally exposed in the signed, client-readable access token, and
+        /// possessing it grants no ability to revoke the session — retirement is a server-only operation via
+        /// <see cref="IRefreshTokenService.RetireFamilyAsync"/>.
+        /// </summary>
+        RefreshFamilyId,
     }
 }

--- a/EasyReasy.Auth/FamilyRetirementResult.cs
+++ b/EasyReasy.Auth/FamilyRetirementResult.cs
@@ -1,0 +1,27 @@
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// Represents a request to retire a single refresh token family because a re-issue superseded it.
+    /// Surfaced to <see cref="IAuthAuditLogger.OnSessionSupersededAsync"/> so consumers can record the
+    /// supersession as its own audit event, distinct from a real logout or bulk revocation.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately distinct from <see cref="SessionRevocationResult"/>, which carries a count of families
+    /// revoked by a bulk or single-session operation: this names the one family that was retired. Because
+    /// <see cref="IRefreshTokenStore.InvalidateFamilyAsync"/> reports neither whether the family existed nor
+    /// which subject it belonged to, the record means "a retire was requested for this family";
+    /// <see cref="Subject"/> is supplied by the caller (from the access token) purely for the audit row.
+    /// </remarks>
+    public sealed class FamilyRetirementResult
+    {
+        /// <summary>
+        /// The identifier of the refresh token family that was retired.
+        /// </summary>
+        public required string FamilyId { get; init; }
+
+        /// <summary>
+        /// The subject (user identifier) the retired family belonged to, when the caller supplied it; otherwise null.
+        /// </summary>
+        public string? Subject { get; init; }
+    }
+}

--- a/EasyReasy.Auth/HttpContextExtensions.cs
+++ b/EasyReasy.Auth/HttpContextExtensions.cs
@@ -24,6 +24,17 @@ namespace EasyReasy.Auth
         }
 
         /// <summary>
+        /// Gets the refresh token family id (claim type <c>"family_id"</c>) from the HTTP context, if available.
+        /// This is the client's own opaque session identifier; it is intentionally readable from the signed
+        /// access token, and possessing it grants no ability to revoke the session — retirement is a
+        /// server-only operation via <see cref="IRefreshTokenService.RetireFamilyAsync"/>. A re-mint endpoint
+        /// reads it to name the prior family it wants to retire.
+        /// </summary>
+        /// <param name="context">The HTTP context.</param>
+        /// <returns>The refresh token family id, or null if not available.</returns>
+        public static string? GetRefreshFamilyId(this HttpContext context) => context.GetClaimValue("family_id");
+
+        /// <summary>
         /// Gets the user id from the HTTP context, if available.
         /// </summary>
         /// <param name="context">The HTTP context.</param>
@@ -88,6 +99,8 @@ namespace EasyReasy.Auth
                     return context.GetClaimValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Email);
                 case EasyReasyClaim.AuthType:
                     return context.GetClaimValue("auth_type");
+                case EasyReasyClaim.RefreshFamilyId:
+                    return context.GetClaimValue("family_id");
                 case EasyReasyClaim.Issuer:
                     // JWT Issuer is not a claim, but a property on the token. Try to get it from ClaimsPrincipal if available.
                     ClaimsIdentity? jwt = context.User.Identity as ClaimsIdentity;

--- a/EasyReasy.Auth/IAuthAuditLogger.cs
+++ b/EasyReasy.Auth/IAuthAuditLogger.cs
@@ -114,5 +114,26 @@ namespace EasyReasy.Auth
         /// </remarks>
         /// <param name="result">The subject and the number of prior sessions revoked by the new login.</param>
         Task OnConcurrentSessionsRevokedAsync(SessionRevocationResult result) => Task.CompletedTask;
+
+        /// <summary>
+        /// Invoked when a specific prior refresh-token family is retired because a re-issue superseded it —
+        /// the targeted counterpart to <see cref="IRefreshTokenService.RetireFamilyAsync"/>. Fired from inside
+        /// <see cref="RefreshTokenService"/> whenever a non-empty family id is retired, so both HTTP-endpoint
+        /// and programmatic callers trigger it.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately distinct from <see cref="OnLogoutAsync"/> (an actual logout) and from
+        /// <see cref="OnConcurrentSessionsRevokedAsync"/> (global single-session enforcement that kills the
+        /// subject's other sessions): this one means "this one prior session was superseded by a re-issue,"
+        /// leaving the subject's other sessions untouched. Because the underlying store call reports neither
+        /// existence nor a subject, the record means "a retire was requested for this family."
+        /// </remarks>
+        /// <param name="httpContext">
+        /// The HTTP context of the request that triggered the event, or <c>null</c> when invoked programmatically
+        /// (e.g. from a background service). Implementations should guard against null when recording IP or
+        /// User-Agent data.
+        /// </param>
+        /// <param name="result">The retired family id and, when the caller supplied it, the subject.</param>
+        Task OnSessionSupersededAsync(HttpContext? httpContext, FamilyRetirementResult result) => Task.CompletedTask;
     }
 }

--- a/EasyReasy.Auth/IRefreshTokenService.cs
+++ b/EasyReasy.Auth/IRefreshTokenService.cs
@@ -21,6 +21,25 @@ namespace EasyReasy.Auth
         Task<string> CreateRefreshTokenAsync(string subject, string authType, string? serializedClaims, string? serializedRoles, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Creates a new refresh token for the specified subject and stores it, returning both the raw token
+        /// and the generated family identifier. Identical to <see cref="CreateRefreshTokenAsync"/> in every
+        /// other respect — it is the single code path both methods share.
+        /// </summary>
+        /// <remarks>
+        /// Use this overload when the caller needs the <see cref="RefreshTokenCreationResult.FamilyId"/>, for
+        /// example to seed the <c>family_id</c> claim onto the very first (login) access token, or to later
+        /// retire that exact family via <see cref="RetireFamilyAsync"/>. (A return-type-only overload is not
+        /// legal C#, hence the distinct name.)
+        /// </remarks>
+        /// <param name="subject">The subject (user identifier) the token is for.</param>
+        /// <param name="authType">The authentication type (e.g., "apikey" or "user").</param>
+        /// <param name="serializedClaims">JSON-serialized additional claims, or null if none.</param>
+        /// <param name="serializedRoles">JSON-serialized roles, or null if none.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
+        /// <returns>The raw refresh token and the family identifier that was created.</returns>
+        Task<RefreshTokenCreationResult> CreateRefreshTokenWithFamilyAsync(string subject, string authType, string? serializedClaims, string? serializedRoles, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Validates a refresh token and issues a new access token and refresh token pair.
         /// Implements token rotation with theft detection — if a consumed token is reused,
         /// the entire token family is invalidated.
@@ -79,5 +98,43 @@ namespace EasyReasy.Auth
         /// no active sessions at the time of the call.
         /// </returns>
         Task<SessionRevocationResult> InvalidateAllSessionsAsync(string subject, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retires exactly one refresh token family, leaving the subject's other sessions (other devices)
+        /// untouched. Intended for a re-issue endpoint that re-mints a token pair for an already-authenticated
+        /// subject (for example an active-organization switch) and wants to retire the caller's prior family as
+        /// part of the re-mint.
+        /// </summary>
+        /// <remarks>
+        /// When an <see cref="IAuthAuditLogger"/> is registered and a non-empty <paramref name="familyId"/> is
+        /// passed, the retirement is reported through <see cref="IAuthAuditLogger.OnSessionSupersededAsync"/> —
+        /// not <see cref="IAuthAuditLogger.OnLogoutAsync"/> — so the event reads as a supersession rather than a
+        /// logout. This is the targeted, audited counterpart to <see cref="IRefreshTokenStore.InvalidateFamilyAsync"/>,
+        /// distinct from the global <see cref="ConcurrentSessionPolicy.SingleSession"/> enforcement (which kills
+        /// every other session) and from the bulk <see cref="InvalidateAllSessionsAsync"/>.
+        /// <para>
+        /// Security: the service performs no ownership check (it cannot map a family id to a subject), so source
+        /// <paramref name="familyId"/> only from the caller's own authenticated access token — e.g.
+        /// <see cref="HttpContextExtensions.GetRefreshFamilyId"/> — never from an untrusted request parameter.
+        /// Because <c>family_id</c> is readable in the signed JWT, echoing a client-supplied value back here would
+        /// let one caller retire another's session.
+        /// </para>
+        /// </remarks>
+        /// <param name="familyId">
+        /// The family identifier to retire. <c>null</c> or whitespace is a no-op — no store call, no audit hook,
+        /// no throw. This is the normal path for an access token minted before the <c>family_id</c> claim
+        /// existed, so callers can pass <see cref="HttpContextExtensions.GetRefreshFamilyId"/> directly.
+        /// </param>
+        /// <param name="subject">
+        /// The subject (user identifier) the family belongs to, recorded only on the audit row. The service
+        /// cannot derive it from a family id, so the caller supplies it from the access token
+        /// (e.g. <see cref="HttpContextExtensions.GetUserId"/>). Optional.
+        /// </param>
+        /// <param name="httpContext">
+        /// The HTTP context of the triggering request, when called from an HTTP endpoint. Pass <c>null</c> for
+        /// programmatic calls. Only used to propagate context to <see cref="IAuthAuditLogger.OnSessionSupersededAsync"/>.
+        /// </param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
+        Task RetireFamilyAsync(string? familyId, string? subject = null, HttpContext? httpContext = null, CancellationToken cancellationToken = default);
     }
 }

--- a/EasyReasy.Auth/README.md
+++ b/EasyReasy.Auth/README.md
@@ -288,6 +288,10 @@ string? email = HttpContext.GetClaimValue("email");
 string? userId2 = HttpContext.GetClaimValue(EasyReasyClaim.UserId);
 string? tenantId2 = HttpContext.GetClaimValue(EasyReasyClaim.TenantId);
 string? issuer = HttpContext.GetClaimValue(EasyReasyClaim.Issuer);
+
+// The refresh token family id rides on the access token as the "family_id" claim (see Section 9).
+string? familyId = HttpContext.GetRefreshFamilyId();
+string? familyId2 = HttpContext.GetClaimValue(EasyReasyClaim.RefreshFamilyId);
 ```
 
 ### 6. Password Hashing
@@ -582,6 +586,27 @@ builder.Services.AddRefreshTokenService<MyStore>(
 - When enforcement actually revokes at least one prior session, the service fires `IAuthAuditLogger.OnConcurrentSessionsRevokedAsync` — distinct from `OnSessionsInvalidatedAsync` so you can audit automatic, login-driven revocations separately. See Section 10.
 - **Concurrency caveat**: enforcement is two store calls (invalidate, then store), not one transaction. Two logins for the same subject racing concurrently can each miss the other's not-yet-stored family and both stay live. If you need a hard guarantee, serialize concurrent logins for the same subject in your store (a per-subject lock or a unique constraint) — the library cannot, because `IRefreshTokenStore` has no atomic store-and-invalidate-others operation.
 
+**Targeted session supersession on re-issue (`IRefreshTokenService.RetireFamilyAsync`)** — when an endpoint re-mints a fresh token pair for an *already-authenticated* subject (for example an "active organization switch" that re-issues the access token with a changed claim), it mints a **new** refresh-token family while the caller's **prior** family stays live until it expires. To retire *exactly that prior family* as part of the re-mint — and only it, leaving the subject's other devices live — without the misleading `Logout` record that `LogoutAsync` would produce, use `RetireFamilyAsync`:
+
+```csharp
+// At the re-issue endpoint (the caller is already authenticated):
+string? priorFamilyId = HttpContext.GetRefreshFamilyId();
+
+// ... mint the new pair carrying the changed claim, e.g. via IJwtTokenService.CreateToken +
+//     IRefreshTokenService.CreateRefreshTokenAsync (or CreateRefreshTokenWithFamilyAsync if you
+//     want the new family id to seed the family_id claim onto this first access token) ...
+
+// Retire the caller's prior family. Other devices stay live; the event is audited as a
+// supersession (OnSessionSupersededAsync), not a logout.
+await _refreshTokenService.RetireFamilyAsync(priorFamilyId, HttpContext.GetUserId());
+```
+
+- **How the prior family is named.** The refresh token family id is surfaced on every access token as the `family_id` claim, readable with `HttpContext.GetRefreshFamilyId()` (or `EasyReasyClaim.RefreshFamilyId`). The claim is injected authoritatively on every refresh from the server-side family id, so it is stable across a family's rotations and cannot be spoofed via stored claims. Exposing it in the signed, client-readable JWT is intended and safe: it is the client's own opaque session id, and possessing it grants no ability to revoke the session — retirement is a server-only operation.
+- **`subject` is for the audit row only.** The service cannot derive the subject from a family id, so pass it from the access token (`HttpContext.GetUserId()`). It is recorded on the `FamilyRetirementResult`; it does not affect which family is retired.
+- **Null/whitespace is a clean no-op** — no store call, no audit hook, no throw. This is the normal path during rollout: access tokens minted before 5.2.0 carry no `family_id`, so `GetRefreshFamilyId()` returns `null` and `RetireFamilyAsync(null)` simply does nothing. Existing sessions self-heal — each gains the `family_id` claim on its next refresh, no consumer action required.
+- This is the targeted, audited counterpart to `IRefreshTokenStore.InvalidateFamilyAsync` — distinct from the global `SingleSession` policy (which kills every other session) and from the bulk `InvalidateAllSessionsAsync`. When a non-empty family id is retired, the service fires `IAuthAuditLogger.OnSessionSupersededAsync`. See Section 10.
+- **Assumes `ConcurrentSessionPolicy.AllowMultiple` (the default).** Under `SingleSession`, minting the new pair already revokes the subject's *other* families during creation, so the prior family is gone before `RetireFamilyAsync` runs and "other devices stay live" no longer applies — targeted retirement is redundant there.
+
 ### 10. Security Audit Logging (ISO 27001 A.9 / A.12)
 
 Every authentication event the library surfaces — success or failure — is reported through a single optional DI service: `IAuthAuditLogger`. Register an implementation and the built-in endpoints (plus the programmatic triggers `RefreshTokenService.InvalidateAllSessionsAsync` and single-session enforcement on login) will invoke it with a structured result object.
@@ -594,6 +619,7 @@ Every authentication event the library surfaces — success or failure — is re
 | Logout | `OnLogoutAsync(httpContext, LogoutResult)` | ISO 27001 A.9.2.6 | `WasKnown`, `Subject`, `FamilyId`, IP, time |
 | Bulk session revocation | `OnSessionsInvalidatedAsync(SessionRevocationResult)` | ISO 27001 A.9.2.6 | `Subject`, `InvalidatedFamilyCount`, time |
 | Concurrent session revoked on login (`SingleSession` policy) | `OnConcurrentSessionsRevokedAsync(SessionRevocationResult)` | ISO 27001 A.9.2.6 | `Subject`, `InvalidatedFamilyCount`, time |
+| Targeted session supersession on re-issue (`RetireFamilyAsync`) | `OnSessionSupersededAsync(httpContext, FamilyRetirementResult)` | ISO 27001 A.9.2.6 | `FamilyId`, `Subject`, IP, time |
 
 All methods have default no-op implementations — implement only the events you care about. The result objects deliberately never carry a raw password or a raw API key, so failure records are safe to serialise to your log store.
 
@@ -645,6 +671,16 @@ public class MyAuditLogger : IAuthAuditLogger
         _logger.LogInformation(
             "auth.sessions_revoked subject={Subject} count={Count}",
             result.Subject, result.InvalidatedFamilyCount);
+        return Task.CompletedTask;
+    }
+
+    public Task OnSessionSupersededAsync(HttpContext? ctx, FamilyRetirementResult result)
+    {
+        // A specific prior session was retired by a re-issue (see Section 9) — distinct from a
+        // logout and from global single-session enforcement.
+        _logger.LogInformation(
+            "auth.session_superseded subject={Subject} family={Family}",
+            result.Subject, result.FamilyId);
         return Task.CompletedTask;
     }
 }
@@ -832,6 +868,20 @@ The progressive delay middleware helps protect your API from brute-force attacks
 ---
 
 For more details, see XML comments in the code or explore the source. This library is designed to be easy to use and secure enough for most uses cases by default.
+
+## Migration from 5.1.0
+
+Version 5.2.0 is additive. Existing callers using the built-in `RefreshTokenService` compile and behave identically. The new capability is targeted retirement of a single prior refresh-token family at token re-issue. See Section 9 "Targeted session supersession on re-issue".
+
+### New: name and retire a prior family at re-issue
+- **`IRefreshTokenService.CreateRefreshTokenWithFamilyAsync`** returns a `RefreshTokenCreationResult` carrying both the `RawToken` and the generated `FamilyId`. The existing `CreateRefreshTokenAsync` is unchanged — it now delegates to this single shared code path and returns `result.RawToken`.
+- **`EasyReasyClaim.RefreshFamilyId` / `HttpContext.GetRefreshFamilyId()`** read the `family_id` claim. The refresh path injects this claim authoritatively from the server-side family id on every refresh, so it is stable across rotations and cannot be spoofed via stored claims.
+- **`IRefreshTokenService.RetireFamilyAsync(familyId, subject?, httpContext?, ct)`** retires exactly one family (other devices stay live). Null/whitespace family id is a no-op. When a non-empty family id is retired and an audit logger is registered, it fires the new hook.
+- **New `IAuthAuditLogger.OnSessionSupersededAsync(httpContext, FamilyRetirementResult)` hook** reports the supersession. It has a default no-op implementation, so existing audit loggers are unaffected. Distinct from `OnLogoutAsync` (a real logout) and `OnConcurrentSessionsRevokedAsync` (global single-session enforcement).
+
+**Rollout is safe with no consumer action.** Access tokens minted before 5.2.0 carry no `family_id`, so `GetRefreshFamilyId()` returns `null` and `RetireFamilyAsync(null)` is a clean no-op. Existing sessions self-heal — each gains the `family_id` claim on its next refresh. A consumer that wants the claim on the very first (login) access token adds it itself using the `FamilyId` from `CreateRefreshTokenWithFamilyAsync`.
+
+**`IRefreshTokenService` gains two methods; nothing else changes.** No `IRefreshTokenStore`, DI-registration, or wire-format changes, and the new `IAuthAuditLogger` member is a default-method addition so existing audit loggers keep compiling. The two new `IRefreshTokenService` methods are *not* default-implemented, so a **custom `IRefreshTokenService` implementation** (rare — most consumers implement only `IRefreshTokenStore` and use the built-in service) must add `CreateRefreshTokenWithFamilyAsync` and `RetireFamilyAsync`.
 
 ## Migration from 5.0.0
 

--- a/EasyReasy.Auth/RefreshTokenCreationResult.cs
+++ b/EasyReasy.Auth/RefreshTokenCreationResult.cs
@@ -1,0 +1,26 @@
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// The result of creating a new refresh token via
+    /// <see cref="IRefreshTokenService.CreateRefreshTokenWithFamilyAsync"/>, exposing both the raw token
+    /// string to return to the client and the generated family identifier.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="FamilyId"/> lets a caller that re-mints a token pair for an already-authenticated
+    /// subject (for example an active-organization switch endpoint) later retire that exact family via
+    /// <see cref="IRefreshTokenService.RetireFamilyAsync"/>, or seed the <c>family_id</c> claim onto the
+    /// very first (login) access token itself.
+    /// </remarks>
+    public sealed class RefreshTokenCreationResult
+    {
+        /// <summary>
+        /// The raw refresh token string to return to the client.
+        /// </summary>
+        public required string RawToken { get; init; }
+
+        /// <summary>
+        /// The identifier of the refresh token family that was created. Stable across the family's rotations.
+        /// </summary>
+        public required string FamilyId { get; init; }
+    }
+}

--- a/EasyReasy.Auth/RefreshTokenService.cs
+++ b/EasyReasy.Auth/RefreshTokenService.cs
@@ -29,12 +29,11 @@ namespace EasyReasy.Auth
         /// The lifetime of access tokens created during refresh. Defaults to 1 hour if not specified.
         /// </param>
         /// <param name="auditLogger">
-        /// Optional audit logger. When supplied, this service invokes the matching hook after every
-        /// <see cref="RefreshAsync"/> (<see cref="IAuthAuditLogger.OnRefreshAsync"/>),
-        /// <see cref="LogoutAsync"/> (<see cref="IAuthAuditLogger.OnLogoutAsync"/>), and
-        /// <see cref="InvalidateAllSessionsAsync"/> (<see cref="IAuthAuditLogger.OnSessionsInvalidatedAsync"/>) call
-        /// so consumers can emit ISO 27001 A.12.4.1 / A.9.2.6 audit records for both HTTP-driven and programmatic flows.
-        /// Lifetime must be at least as long as this service — see <see cref="IAuthAuditLogger"/> remarks.
+        /// Optional audit logger. When supplied, this service invokes the matching service-layer hook after the
+        /// corresponding operation completes, so consumers can emit ISO 27001 A.12.4.1 / A.9.2.6 audit records for
+        /// both HTTP-driven and programmatic flows. See <see cref="IAuthAuditLogger"/> for the full set of hooks
+        /// and which fire from the service versus the endpoint layer. Lifetime must be at least as long as this
+        /// service — see <see cref="IAuthAuditLogger"/> remarks.
         /// </param>
         /// <param name="claimsResolver">
         /// Optional consumer-supplied claims/roles resolver. When supplied, this service invokes the
@@ -73,6 +72,20 @@ namespace EasyReasy.Auth
             string? serializedRoles,
             CancellationToken cancellationToken = default)
         {
+            // Delegate to the detailed overload so there is exactly one creation code path; this method
+            // simply discards the family id that existing callers do not need.
+            RefreshTokenCreationResult result = await CreateRefreshTokenWithFamilyAsync(subject, authType, serializedClaims, serializedRoles, cancellationToken);
+            return result.RawToken;
+        }
+
+        /// <inheritdoc />
+        public async Task<RefreshTokenCreationResult> CreateRefreshTokenWithFamilyAsync(
+            string subject,
+            string authType,
+            string? serializedClaims,
+            string? serializedRoles,
+            CancellationToken cancellationToken = default)
+        {
             string rawToken = GenerateToken();
             string tokenHash = HashToken(rawToken);
             string familyId = Guid.NewGuid().ToString();
@@ -103,7 +116,7 @@ namespace EasyReasy.Auth
                 await _auditLogger.OnConcurrentSessionsRevokedAsync(new SessionRevocationResult(subject, invalidatedFamilyCount));
             }
 
-            return rawToken;
+            return new RefreshTokenCreationResult { RawToken = rawToken, FamilyId = familyId };
         }
 
         /// <summary>
@@ -244,10 +257,20 @@ namespace EasyReasy.Auth
             }
 
             DateTime accessTokenExpiresAt = now.Add(_accessTokenLifetime);
+
+            // The family id rides on the access token as the authoritative "family_id" claim so a re-issue
+            // endpoint can name and retire exactly this prior family. The value always comes from
+            // storedToken.FamilyId (copied onto every rotation's row, so it is stable across the family's
+            // lifetime) — never from caller-supplied stored claims — so any value already present is stripped
+            // and replaced here, and it cannot be spoofed via SerializedClaims. Built as a separate list so it
+            // is not persisted into the new row's serialized claims; the re-injection above is the single source.
+            List<Claim> accessTokenClaims = claims.Where(claim => claim.Type != "family_id").ToList();
+            accessTokenClaims.Add(new Claim("family_id", storedToken.FamilyId));
+
             string accessToken = jwtTokenService.CreateToken(
                 storedToken.Subject,
                 storedToken.AuthType,
-                claims,
+                accessTokenClaims,
                 roles,
                 accessTokenExpiresAt);
 
@@ -331,6 +354,28 @@ namespace EasyReasy.Auth
             }
 
             return result;
+        }
+
+        /// <inheritdoc />
+        public async Task RetireFamilyAsync(string? familyId, string? subject = null, HttpContext? httpContext = null, CancellationToken cancellationToken = default)
+        {
+            // A null/whitespace family id can't name any family — no-op so a re-issue endpoint can pass
+            // HttpContext.GetRefreshFamilyId() directly (it is null for access tokens minted before the claim
+            // existed) without a store call, an audit record, or a throw.
+            if (string.IsNullOrWhiteSpace(familyId))
+            {
+                return;
+            }
+
+            await _store.InvalidateFamilyAsync(familyId, cancellationToken);
+
+            // Fire after the retire lands, matching the other hook sites. The store reports neither existence
+            // nor a subject, so the record means "a retire was requested for this family"; subject rides along
+            // only for the audit row.
+            if (_auditLogger != null)
+            {
+                await _auditLogger.OnSessionSupersededAsync(httpContext, new FamilyRetirementResult { FamilyId = familyId, Subject = subject });
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Why?
Closes #11.

A consumer that re-mints a fresh token pair for an already-authenticated subject (e.g. an active-organization switch that re-issues the access token with a changed claim) mints a *new* refresh-token family while the caller's *prior* family stays live until it expires — leaving a stray session lineage behind. There was no way to retire exactly that prior family (and only it) as part of the re-mint, nor to audit it as anything other than a misleading logout.

## What?
Additive changes to `EasyReasy.Auth` (5.1.0 → 5.2.0):
- **`CreateRefreshTokenWithFamilyAsync`** returns the generated family id (`RefreshTokenCreationResult`); the legacy `CreateRefreshTokenAsync` now delegates to it.
- **`family_id` access-token claim** (`EasyReasyClaim.RefreshFamilyId` / `HttpContext.GetRefreshFamilyId()`), injected authoritatively from the server-side family id on every refresh — stable across rotations, not spoofable via stored claims.
- **`RetireFamilyAsync(familyId, subject?, …)`** retires exactly one family (other devices stay live); null/whitespace is a clean no-op.
- **`OnSessionSupersededAsync` audit hook + `FamilyRetirementResult`** — default-implemented so existing loggers are unaffected; distinct from logout and from global single-session enforcement.
- README updated (re-issue/supersede pattern, migration + rollout/self-heal note) and full test coverage.

## Challenges
- The `family_id` claim is built onto a *separate* access-token claim list and never persisted into stored claims, so the authoritative server-side value is the single source and a spoofed value in serialized claims is stripped on every refresh.
- The two new `IRefreshTokenService` methods can't be default-implemented (both need the store), so they're plain interface additions. Kept as a 5.2.0 minor bump: the break affects only rare *direct* `IRefreshTokenService` implementers — consumers using the built-in service are unaffected.
- Review-driven: renamed `CreateRefreshTokenDetailedAsync` → `CreateRefreshTokenWithFamilyAsync` for a clearer public name, and documented that the supersession pattern assumes `ConcurrentSessionPolicy.AllowMultiple`.

## Left for future work
- A project-wide claim-name constants pass (`tenant_id`, `auth_type`, `family_id` are bare literals by existing convention) — deliberately out of scope here to avoid local inconsistency.