### PR TITLE
Add RFC 6238 TOTP and AES-256-GCM secret cipher primitives

### DIFF
--- a/EasyReasy.Auth.Tests/AesGcmSecretCipherTests.cs
+++ b/EasyReasy.Auth.Tests/AesGcmSecretCipherTests.cs
@@ -1,0 +1,127 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace EasyReasy.Auth.Tests
+{
+    [TestClass]
+    public class AesGcmSecretCipherTests
+    {
+        private static byte[] NewKey()
+        {
+            return RandomNumberGenerator.GetBytes(32);
+        }
+
+        [TestMethod]
+        public void EncryptThenDecrypt_RoundTripsPlaintext()
+        {
+            AesGcmSecretCipher cipher = new AesGcmSecretCipher(NewKey());
+            byte[] plaintext = Encoding.UTF8.GetBytes("a totp secret");
+
+            byte[] envelope = cipher.Encrypt(plaintext);
+            byte[] decrypted = cipher.Decrypt(envelope);
+
+            CollectionAssert.AreEqual(plaintext, decrypted);
+        }
+
+        [TestMethod]
+        public void Encrypt_ProducesDifferentCiphertextEachTime_DueToRandomNonce()
+        {
+            AesGcmSecretCipher cipher = new AesGcmSecretCipher(NewKey());
+            byte[] plaintext = Encoding.UTF8.GetBytes("same input");
+
+            byte[] first = cipher.Encrypt(plaintext);
+            byte[] second = cipher.Encrypt(plaintext);
+
+            CollectionAssert.AreNotEqual(first, second);
+            // Both still decrypt back to the same plaintext.
+            CollectionAssert.AreEqual(plaintext, cipher.Decrypt(first));
+            CollectionAssert.AreEqual(plaintext, cipher.Decrypt(second));
+        }
+
+        [TestMethod]
+        public void EnvelopeVersion_IsStampedAsLeadingEnvelopeByte()
+        {
+            AesGcmSecretCipher cipher = new AesGcmSecretCipher(NewKey());
+            byte[] envelope = cipher.Encrypt(new byte[] { 1, 2, 3 });
+            Assert.AreEqual(cipher.EnvelopeVersion, envelope[0]);
+        }
+
+        [TestMethod]
+        public void Decrypt_TamperedCiphertext_Throws()
+        {
+            AesGcmSecretCipher cipher = new AesGcmSecretCipher(NewKey());
+            byte[] envelope = cipher.Encrypt(Encoding.UTF8.GetBytes("secret"));
+            envelope[^1] ^= 0xFF; // flip a ciphertext byte
+
+            Assert.ThrowsException<AuthenticationTagMismatchException>(() => cipher.Decrypt(envelope));
+        }
+
+        [TestMethod]
+        public void Decrypt_WithWrongKey_Throws()
+        {
+            byte[] plaintext = Encoding.UTF8.GetBytes("secret");
+            byte[] envelope = new AesGcmSecretCipher(NewKey()).Encrypt(plaintext);
+
+            AesGcmSecretCipher otherCipher = new AesGcmSecretCipher(NewKey());
+            Assert.ThrowsException<AuthenticationTagMismatchException>(() => otherCipher.Decrypt(envelope));
+        }
+
+        [TestMethod]
+        public void Decrypt_UnsupportedVersionByte_Throws()
+        {
+            AesGcmSecretCipher cipher = new AesGcmSecretCipher(NewKey());
+            byte[] envelope = cipher.Encrypt(new byte[] { 9 });
+            envelope[0] = 0x7F;
+
+            Assert.ThrowsException<CryptographicException>(() => cipher.Decrypt(envelope));
+        }
+
+        [TestMethod]
+        public void Decrypt_TooShortEnvelope_Throws()
+        {
+            AesGcmSecretCipher cipher = new AesGcmSecretCipher(NewKey());
+            Assert.ThrowsException<CryptographicException>(() => cipher.Decrypt(new byte[] { 1, 2, 3 }));
+        }
+
+        [DataTestMethod]
+        [DataRow(16)]
+        [DataRow(31)]
+        [DataRow(64)]
+        public void Constructor_NonAes256Key_Throws(int keyLength)
+        {
+            Assert.ThrowsException<ArgumentException>(() => new AesGcmSecretCipher(new byte[keyLength]));
+        }
+
+        [TestMethod]
+        public void Constructor_NullKey_Throws()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => new AesGcmSecretCipher(null!));
+        }
+
+        [TestMethod]
+        public void EncryptThenDecrypt_EmptyPlaintext_RoundTrips()
+        {
+            AesGcmSecretCipher cipher = new AesGcmSecretCipher(NewKey());
+
+            byte[] envelope = cipher.Encrypt(Array.Empty<byte>());
+            byte[] decrypted = cipher.Decrypt(envelope);
+
+            Assert.AreEqual(0, decrypted.Length);
+        }
+
+        [TestMethod]
+        public void Constructor_ClonesKey_SoLaterMutationOfCallerArrayHasNoEffect()
+        {
+            byte[] key = NewKey();
+            AesGcmSecretCipher cipher = new AesGcmSecretCipher(key);
+            byte[] envelope = cipher.Encrypt(Encoding.UTF8.GetBytes("secret"));
+
+            // Mutating the caller's array after construction must not affect the cipher's internal key;
+            // if the constructor kept a reference instead of a clone, this decrypt would fail the tag.
+            Array.Clear(key);
+
+            byte[] decrypted = cipher.Decrypt(envelope);
+            Assert.AreEqual("secret", Encoding.UTF8.GetString(decrypted));
+        }
+    }
+}

--- a/EasyReasy.Auth.Tests/Rfc6238TotpGeneratorTests.cs
+++ b/EasyReasy.Auth.Tests/Rfc6238TotpGeneratorTests.cs
@@ -1,0 +1,181 @@
+using System.Text;
+
+namespace EasyReasy.Auth.Tests
+{
+    [TestClass]
+    public class Rfc6238TotpGeneratorTests
+    {
+        // RFC 6238 Appendix B uses the ASCII seed "12345678901234567890" for the SHA-1 vectors.
+        private static readonly byte[] Seed = Encoding.ASCII.GetBytes("12345678901234567890");
+
+        private readonly Rfc6238TotpGenerator _generator = new Rfc6238TotpGenerator();
+
+        // RFC 6238 Appendix B SHA-1 vectors, truncated to the 6 low digits of the published 8-digit code.
+        [DataTestMethod]
+        [DataRow(59L, "287082")]
+        [DataRow(1111111109L, "081804")]
+        [DataRow(1111111111L, "050471")]
+        [DataRow(1234567890L, "005924")]
+        [DataRow(2000000000L, "279037")]
+        [DataRow(20000000000L, "353130")]
+        public void Generate_Rfc6238Vectors_MatchSha1ReferenceCodes(long unixTime, string expected)
+        {
+            long step = _generator.GetTimeStep(DateTimeOffset.FromUnixTimeSeconds(unixTime));
+            string code = _generator.Generate(Seed, step);
+            Assert.AreEqual(expected, code);
+        }
+
+        // RFC 6238 Appendix B SHA-1 vectors at their native 8-digit length.
+        [DataTestMethod]
+        [DataRow(59L, "94287082")]
+        [DataRow(1111111109L, "07081804")]
+        [DataRow(1111111111L, "14050471")]
+        [DataRow(1234567890L, "89005924")]
+        [DataRow(2000000000L, "69279037")]
+        [DataRow(20000000000L, "65353130")]
+        public void Generate_Rfc6238Vectors_MatchSha1EightDigitReferenceCodes(long unixTime, string expected)
+        {
+            Rfc6238TotpGenerator eightDigit = new Rfc6238TotpGenerator(digits: 8);
+            long step = eightDigit.GetTimeStep(DateTimeOffset.FromUnixTimeSeconds(unixTime));
+            string code = eightDigit.Generate(Seed, step);
+            Assert.AreEqual(expected, code);
+        }
+
+        [DataTestMethod]
+        [DataRow(5)]
+        [DataRow(9)]
+        public void Constructor_DigitsOutOfRange_Throws(int digits)
+        {
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new Rfc6238TotpGenerator(digits: digits));
+        }
+
+        [DataTestMethod]
+        [DataRow(0)]
+        [DataRow(-1)]
+        public void Constructor_NonPositiveStepSeconds_Throws(int stepSeconds)
+        {
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new Rfc6238TotpGenerator(stepSeconds: stepSeconds));
+        }
+
+        [TestMethod]
+        public void GetTimeStep_HonorsCustomStepSeconds()
+        {
+            Rfc6238TotpGenerator sixtySecond = new Rfc6238TotpGenerator(stepSeconds: 60);
+            Assert.AreEqual(0L, sixtySecond.GetTimeStep(DateTimeOffset.FromUnixTimeSeconds(59)));
+            Assert.AreEqual(1L, sixtySecond.GetTimeStep(DateTimeOffset.FromUnixTimeSeconds(60)));
+        }
+
+        [TestMethod]
+        public void TryValidate_RoundTripsWithCustomDigitsAndStep()
+        {
+            Rfc6238TotpGenerator custom = new Rfc6238TotpGenerator(digits: 8, stepSeconds: 60);
+            long step = custom.GetTimeStep(DateTimeOffset.FromUnixTimeSeconds(1234567890));
+            string code = custom.Generate(Seed, step);
+
+            bool valid = custom.TryValidate(Seed, code, currentStep: step, window: 1, out long matchedStep);
+
+            Assert.AreEqual(8, code.Length);
+            Assert.IsTrue(valid);
+            Assert.AreEqual(step, matchedStep);
+        }
+
+        [TestMethod]
+        public void GetTimeStep_DividesUnixSecondsByThirty()
+        {
+            Assert.AreEqual(0L, _generator.GetTimeStep(DateTimeOffset.FromUnixTimeSeconds(29)));
+            Assert.AreEqual(1L, _generator.GetTimeStep(DateTimeOffset.FromUnixTimeSeconds(30)));
+            Assert.AreEqual(2L, _generator.GetTimeStep(DateTimeOffset.FromUnixTimeSeconds(75)));
+        }
+
+        [TestMethod]
+        public void TryValidate_CorrectCodeForCurrentStep_ReturnsTrueWithMatchedStep()
+        {
+            long step = 1000;
+            string code = _generator.Generate(Seed, step);
+
+            bool valid = _generator.TryValidate(Seed, code, currentStep: step, window: 1, out long matchedStep);
+
+            Assert.IsTrue(valid);
+            Assert.AreEqual(step, matchedStep);
+        }
+
+        [DataTestMethod]
+        [DataRow(-1)]
+        [DataRow(1)]
+        public void TryValidate_CodeWithinClockSkewWindow_IsAccepted(int stepOffset)
+        {
+            long actualStep = 5000 + stepOffset;
+            string code = _generator.Generate(Seed, actualStep);
+
+            bool valid = _generator.TryValidate(Seed, code, currentStep: 5000, window: 1, out long matchedStep);
+
+            Assert.IsTrue(valid);
+            Assert.AreEqual(actualStep, matchedStep);
+        }
+
+        [TestMethod]
+        public void TryValidate_CodeOutsideWindow_IsRejected()
+        {
+            string code = _generator.Generate(Seed, 5000 + 2);
+            bool valid = _generator.TryValidate(Seed, code, currentStep: 5000, window: 1, out _);
+            Assert.IsFalse(valid);
+        }
+
+        [DataTestMethod]
+        [DataRow("")]
+        [DataRow("12345")]   // too short
+        [DataRow("1234567")] // too long
+        [DataRow("12ab56")]  // non-digit
+        public void TryValidate_MalformedCode_IsRejected(string code)
+        {
+            bool valid = _generator.TryValidate(Seed, code, currentStep: 5000, window: 1, out _);
+            Assert.IsFalse(valid);
+        }
+
+        [TestMethod]
+        public void TryValidate_CodeWithEmbeddedSpaces_IsAccepted()
+        {
+            long step = 5000;
+            string code = _generator.Generate(Seed, step); // 6 digits, e.g. "123456"
+            string spaced = code.Insert(3, " ");           // grouped display, e.g. "123 456"
+
+            bool valid = _generator.TryValidate(Seed, spaced, currentStep: step, window: 1, out long matchedStep);
+
+            Assert.IsTrue(valid);
+            Assert.AreEqual(step, matchedStep);
+        }
+
+        [TestMethod]
+        public void TryValidate_CodeWithSurroundingNonSpaceWhitespace_IsAccepted()
+        {
+            long step = 5000;
+            string code = _generator.Generate(Seed, step);
+            string wrapped = "\t" + code + "\n"; // tab/newline from a paste — stripped by Trim, not by the space replace
+
+            bool valid = _generator.TryValidate(Seed, wrapped, currentStep: step, window: 1, out long matchedStep);
+
+            Assert.IsTrue(valid);
+            Assert.AreEqual(step, matchedStep);
+        }
+
+        [TestMethod]
+        public void TryValidate_NegativeWindow_Throws()
+        {
+            string code = _generator.Generate(Seed, 5000);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(
+                () => _generator.TryValidate(Seed, code, currentStep: 5000, window: -1, out _));
+        }
+
+        [TestMethod]
+        public void TryValidate_WrongSecret_IsRejected()
+        {
+            long step = 5000;
+            string code = _generator.Generate(Seed, step);
+            byte[] otherSecret = Encoding.ASCII.GetBytes("09876543210987654321");
+
+            bool valid = _generator.TryValidate(otherSecret, code, currentStep: step, window: 1, out _);
+
+            Assert.IsFalse(valid);
+        }
+    }
+}

--- a/EasyReasy.Auth/AesGcmSecretCipher.cs
+++ b/EasyReasy.Auth/AesGcmSecretCipher.cs
@@ -1,0 +1,89 @@
+using System.Security.Cryptography;
+
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// AES-256-GCM implementation of <see cref="ISecretCipher"/>. The envelope layout is
+    /// <c>[version:1][nonce:12][tag:16][ciphertext:n]</c>. GCM provides confidentiality and
+    /// integrity in one pass, so a tampered or wrong-key ciphertext fails closed at
+    /// <see cref="Decrypt"/> rather than returning garbage. The leading version byte is bound as
+    /// associated data, so it is authenticated alongside the ciphertext. A fresh random nonce is
+    /// generated per encryption (never reused with the same key, which would be catastrophic for GCM).
+    /// </summary>
+    public sealed class AesGcmSecretCipher : ISecretCipher
+    {
+        /// <summary>Current envelope format version. Bump when the envelope layout changes.</summary>
+        private const byte CurrentVersion = 1;
+
+        private const int KeySize = 32; // AES-256
+        private const int NonceSize = 12; // 96-bit nonce — the GCM standard / AesGcm default
+        private const int TagSize = 16; // 128-bit authentication tag
+        private const int HeaderSize = 1 + NonceSize + TagSize;
+
+        private readonly byte[] _key;
+
+        /// <summary>
+        /// Initializes the cipher with a 32-byte (AES-256) key.
+        /// </summary>
+        /// <param name="key">The 256-bit symmetric key.</param>
+        /// <exception cref="ArgumentException">The key is not exactly 32 bytes.</exception>
+        public AesGcmSecretCipher(byte[] key)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+            if (key.Length != KeySize)
+            {
+                throw new ArgumentException($"AES-256 key must be exactly {KeySize} bytes; got {key.Length}.", nameof(key));
+            }
+
+            _key = (byte[])key.Clone();
+        }
+
+        /// <inheritdoc />
+        public byte EnvelopeVersion => CurrentVersion;
+
+        /// <inheritdoc />
+        public byte[] Encrypt(ReadOnlySpan<byte> plaintext)
+        {
+            byte[] envelope = new byte[HeaderSize + plaintext.Length];
+            envelope[0] = CurrentVersion;
+
+            Span<byte> nonce = envelope.AsSpan(1, NonceSize);
+            Span<byte> tag = envelope.AsSpan(1 + NonceSize, TagSize);
+            Span<byte> ciphertext = envelope.AsSpan(HeaderSize);
+
+            RandomNumberGenerator.Fill(nonce);
+
+            using AesGcm aes = new AesGcm(_key, TagSize);
+            // Bind the version byte as associated data so it is covered by the authentication tag —
+            // once more than one version is accepted, a swapped version byte fails to verify.
+            aes.Encrypt(nonce, plaintext, ciphertext, tag, envelope.AsSpan(0, 1));
+
+            return envelope;
+        }
+
+        /// <inheritdoc />
+        public byte[] Decrypt(ReadOnlySpan<byte> envelope)
+        {
+            if (envelope.Length < HeaderSize)
+            {
+                throw new CryptographicException("Ciphertext envelope is too short to be valid.");
+            }
+
+            if (envelope[0] != CurrentVersion)
+            {
+                throw new CryptographicException($"Unsupported ciphertext envelope version {envelope[0]}.");
+            }
+
+            ReadOnlySpan<byte> nonce = envelope.Slice(1, NonceSize);
+            ReadOnlySpan<byte> tag = envelope.Slice(1 + NonceSize, TagSize);
+            ReadOnlySpan<byte> ciphertext = envelope.Slice(HeaderSize);
+
+            byte[] plaintext = new byte[ciphertext.Length];
+
+            using AesGcm aes = new AesGcm(_key, TagSize);
+            aes.Decrypt(nonce, ciphertext, tag, plaintext, envelope.Slice(0, 1));
+
+            return plaintext;
+        }
+    }
+}

--- a/EasyReasy.Auth/EasyReasy.Auth.csproj
+++ b/EasyReasy.Auth/EasyReasy.Auth.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <VersionPrefix>5.3.0</VersionPrefix>
+    <VersionPrefix>5.4.0</VersionPrefix>
     <PackageIcon>BaseIcon.png</PackageIcon>
   </PropertyGroup>
 

--- a/EasyReasy.Auth/ISecretCipher.cs
+++ b/EasyReasy.Auth/ISecretCipher.cs
@@ -1,0 +1,40 @@
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// Symmetric authenticated encryption for small secrets that must be recoverable in plaintext
+    /// to be used (unlike a one-way password hash) — for example a per-user TOTP shared secret held
+    /// encrypted at rest. The intended pattern is to keep the key outside the datastore (e.g. in an
+    /// environment variable) so a database or backup dump alone cannot recover the secret.
+    /// </summary>
+    /// <remarks>
+    /// Output is a self-describing envelope with a leading version byte, so the format can evolve
+    /// and <see cref="Decrypt"/> needs no out-of-band metadata. <see cref="EnvelopeVersion"/> exposes
+    /// that byte so callers can persist it alongside the ciphertext and see which format a stored
+    /// value uses without opening the envelope — useful when migrating to a later envelope layout.
+    /// </remarks>
+    public interface ISecretCipher
+    {
+        /// <summary>
+        /// The envelope format version — the leading byte of every ciphertext produced by
+        /// <see cref="Encrypt"/>. Increases when the envelope layout changes.
+        /// </summary>
+        byte EnvelopeVersion { get; }
+
+        /// <summary>
+        /// Encrypts <paramref name="plaintext"/> into a self-describing envelope.
+        /// </summary>
+        /// <param name="plaintext">The secret bytes to encrypt.</param>
+        /// <returns>A new envelope of <c>[version][nonce][tag][ciphertext]</c> that <see cref="Decrypt"/> can recover.</returns>
+        byte[] Encrypt(ReadOnlySpan<byte> plaintext);
+
+        /// <summary>
+        /// Decrypts an envelope produced by <see cref="Encrypt"/>.
+        /// </summary>
+        /// <param name="envelope">An envelope previously produced by <see cref="Encrypt"/>.</param>
+        /// <returns>The recovered plaintext bytes.</returns>
+        /// <exception cref="System.Security.Cryptography.CryptographicException">The envelope is
+        /// malformed, its version is unsupported, or the authentication tag does not verify
+        /// (tamper / wrong key).</exception>
+        byte[] Decrypt(ReadOnlySpan<byte> envelope);
+    }
+}

--- a/EasyReasy.Auth/README.md
+++ b/EasyReasy.Auth/README.md
@@ -18,6 +18,7 @@ EasyReasy.Auth makes it easy to issue, validate, and work with JWT tokens in you
 - **Claim access**: Retrieve any claim value by key or enum with a single call
 - **Progressive delay**: Built-in middleware to slow down brute-force attacks (enabled by default)
 - **Refresh token rotation**: Opt-in refresh tokens with automatic theft detection via token family tracking
+- **MFA primitives**: RFC 6238 TOTP generator and AES-256-GCM secret cipher — storage-agnostic building blocks for time-based one-time-password and encrypt-at-rest flows
 - **Flexible configuration**: Options pattern for JWT settings (issuer, audience, clock skew) and progressive delay tuning
 - **Clear error messages**: Enforces minimum secret length for security
 
@@ -745,6 +746,63 @@ app.UseSerilogRequestLogging(options =>
 
 **OpenTelemetry** — ensure any `AspNetCoreInstrumentationOptions.EnrichWithHttpRequest` callback that captures request bodies checks the same path list.
 
+### 12. TOTP and Secret Encryption Primitives
+
+Two low-level, storage-agnostic building blocks for multi-factor authentication: an RFC 6238 (TOTP) code generator and an AES-256-GCM cipher for holding the shared secret encrypted at rest. They are pure — no clock, no persistence, no DI required — so the enrollment, storage, and replay-protection policy stay entirely in your application.
+
+```csharp
+public sealed class Rfc6238TotpGenerator
+{
+    // Defaults (6 digits, 30-second steps) match mainstream authenticator apps; digits must be 6–8.
+    Rfc6238TotpGenerator(int digits = 6, int stepSeconds = 30);
+    long GetTimeStep(DateTimeOffset timestamp);
+    string Generate(ReadOnlySpan<byte> secret, long timeStep);
+    // Reports the matched step so you can persist it and reject replay.
+    bool TryValidate(ReadOnlySpan<byte> secret, string code, long currentStep, int window, out long matchedStep);
+}
+
+public interface ISecretCipher   // AesGcmSecretCipher is the AES-256-GCM implementation
+{
+    byte EnvelopeVersion { get; }                   // leading envelope byte; increases when the layout changes
+    byte[] Encrypt(ReadOnlySpan<byte> plaintext);   // self-describing envelope: [version][nonce][tag][ciphertext]
+    byte[] Decrypt(ReadOnlySpan<byte> envelope);    // throws on tamper / wrong key
+}
+```
+
+Register the cipher with a 32-byte key kept **outside** your datastore (e.g. an environment variable), so a database or backup dump alone can't recover the secret:
+
+```csharp
+byte[] key = Convert.FromBase64String(Environment.GetEnvironmentVariable("MFA_SECRET_ENCRYPTION_KEY")!);
+builder.Services.AddSingleton<ISecretCipher>(new AesGcmSecretCipher(key));
+builder.Services.AddSingleton<Rfc6238TotpGenerator>();
+```
+
+**Usage example:**
+```csharp
+// Enrollment: generate a secret, store the ciphertext, show the user an otpauth:// URI / QR code.
+byte[] secret = RandomNumberGenerator.GetBytes(20); // 160-bit, the authenticator-app standard
+// Persisting EnvelopeVersion alongside the ciphertext lets you find rows on an older format to re-encrypt.
+await _store.SaveEnrollment(userId, _cipher.Encrypt(secret), _cipher.EnvelopeVersion);
+
+// Verification: decrypt, validate within a ±1-step skew window, then advance the replay high-water-mark.
+byte[] secret = _cipher.Decrypt(await _store.GetCiphertext(userId));
+long currentStep = _totp.GetTimeStep(DateTimeOffset.UtcNow);
+if (_totp.TryValidate(secret, presentedCode, currentStep, window: 1, out long matchedStep)
+    // RFC 6238 §5.2: atomically require matchedStep > the stored last-used step, then store it. This
+    // rejects any code at or below the last accepted step, including a still-in-window neighbour.
+    && await _store.TryAdvanceLastUsedStep(userId, matchedStep))
+{
+    // code accepted
+}
+```
+
+**Key Features:**
+- RFC 6238 TOTP over RFC 4226 HOTP with HMAC-SHA1 (what mainstream authenticator apps implement), configurable digit count and time-step
+- Constant-time code comparison; validation reports the matched step so the caller can reject any code at or below the last accepted step (RFC 6238 §5.2 high-water-mark)
+- AES-256-GCM authenticated encryption — a tampered or wrong-key ciphertext fails closed rather than returning garbage
+- Self-describing ciphertext envelope with a leading, integrity-protected version byte for future format evolution
+- Pure and stateless: the application owns the clock, the secret store, and the atomic replay high-water-mark
+
 ## Advanced Configuration
 
 ### Service Registration Options
@@ -841,6 +899,7 @@ The progressive delay middleware helps protect your API from brute-force attacks
 - **Refresh token rotation**: Opt-in refresh tokens with token family tracking and automatic theft detection
 - **Secure password hashing**: PBKDF2 with HMAC-SHA512, max password length enforcement, and constant-time comparison
 - **Password reset tokens**: Cryptographically secure token generation with SHA-256 hashing for storage
+- **MFA primitives**: RFC 6238 TOTP generator and AES-256-GCM secret cipher — storage-agnostic building blocks for time-based one-time-password and encrypt-at-rest flows
 - **Claims injection middleware**: Makes user/tenant IDs available in `HttpContext.Items`
 - **Role access**: Retrieve all roles for the current user via `GetRoles()`
 - **Claim access**: Retrieve any claim value by key or enum via `GetClaimValue()`

--- a/EasyReasy.Auth/Rfc6238TotpGenerator.cs
+++ b/EasyReasy.Auth/Rfc6238TotpGenerator.cs
@@ -1,0 +1,156 @@
+using System.Buffers.Binary;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace EasyReasy.Auth
+{
+    /// <summary>
+    /// RFC 6238 (TOTP) over RFC 4226 (HOTP) with HMAC-SHA1, the algorithm every mainstream
+    /// authenticator app (Google Authenticator, 1Password, Authy, …) implements by default.
+    /// Implemented in-house — no third-party dependency on this security-critical path, so the
+    /// validation story for the TOTP factor has clean provenance.
+    /// </summary>
+    /// <remarks>
+    /// Pure and stateless: no clock and no persistence live here. The caller supplies the time
+    /// step (so tests are deterministic) and owns replay protection via the matched step that
+    /// <see cref="TryValidate"/> reports.
+    /// </remarks>
+    public sealed class Rfc6238TotpGenerator
+    {
+        /// <summary>Smallest supported code length.</summary>
+        public const int MinDigits = 6;
+
+        /// <summary>Largest supported code length.</summary>
+        public const int MaxDigits = 8;
+
+        /// <summary>Default code length — 6 digits, the authenticator-app standard.</summary>
+        public const int DefaultDigits = 6;
+
+        /// <summary>Default time-step — 30 seconds, the authenticator-app standard.</summary>
+        public const int DefaultStepSeconds = 30;
+
+        private readonly int _digits;
+        private readonly int _stepSeconds;
+        private readonly int _modulo;
+
+        /// <summary>
+        /// Creates a generator with the given code length and time-step. The defaults (6 digits,
+        /// 30-second steps) match what mainstream authenticator apps assume.
+        /// </summary>
+        /// <param name="digits">Code length; must be between <see cref="MinDigits"/> and <see cref="MaxDigits"/>.</param>
+        /// <param name="stepSeconds">Time-step length in seconds; must be positive.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="digits"/> is outside the
+        /// <see cref="MinDigits"/>–<see cref="MaxDigits"/> range, or <paramref name="stepSeconds"/> is not positive.</exception>
+        public Rfc6238TotpGenerator(int digits = DefaultDigits, int stepSeconds = DefaultStepSeconds)
+        {
+            if (digits is < MinDigits or > MaxDigits)
+            {
+                throw new ArgumentOutOfRangeException(nameof(digits), digits, $"TOTP digit count must be between {MinDigits} and {MaxDigits}.");
+            }
+            if (stepSeconds <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(stepSeconds), stepSeconds, "TOTP step must be positive.");
+            }
+
+            _digits = digits;
+            _stepSeconds = stepSeconds;
+            _modulo = (int)Math.Pow(10, digits);
+        }
+
+        /// <summary>
+        /// The time step for an instant: the number of whole <c>stepSeconds</c> intervals since the
+        /// Unix epoch.
+        /// </summary>
+        /// <param name="timestamp">The instant to convert to a time step.</param>
+        /// <returns>The number of whole time-step intervals between the Unix epoch and <paramref name="timestamp"/>.</returns>
+        public long GetTimeStep(DateTimeOffset timestamp)
+        {
+            return timestamp.ToUnixTimeSeconds() / _stepSeconds;
+        }
+
+        /// <summary>
+        /// Computes the code for a given secret and time step.
+        /// </summary>
+        /// <param name="secret">The shared secret bytes.</param>
+        /// <param name="timeStep">The time step to compute the code for (see <see cref="GetTimeStep"/>).</param>
+        /// <returns>The zero-padded numeric code of the configured length.</returns>
+        [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms",
+            Justification = "HMAC-SHA1 is mandated by RFC 6238 / RFC 4226 for TOTP and is what every " +
+                "mainstream authenticator app implements; it is used here for a one-time-password MAC " +
+                "over a time counter, not for collision-resistant hashing.")]
+        public string Generate(ReadOnlySpan<byte> secret, long timeStep)
+        {
+            Span<byte> counter = stackalloc byte[8];
+            BinaryPrimitives.WriteInt64BigEndian(counter, timeStep);
+
+            Span<byte> hash = stackalloc byte[HMACSHA1.HashSizeInBytes];
+            HMACSHA1.HashData(secret, counter, hash);
+
+            // RFC 4226 §5.3 dynamic truncation.
+            int offset = hash[^1] & 0x0F;
+            int binary =
+                ((hash[offset] & 0x7F) << 24) |
+                ((hash[offset + 1] & 0xFF) << 16) |
+                ((hash[offset + 2] & 0xFF) << 8) |
+                (hash[offset + 3] & 0xFF);
+
+            int otp = binary % _modulo;
+            return otp.ToString(CultureInfo.InvariantCulture).PadLeft(_digits, '0');
+        }
+
+        /// <summary>
+        /// Validates a presented code against the steps in <c>[currentStep - window, currentStep + window]</c>
+        /// (clock-skew tolerance). Comparison is constant-time. Returns the matched step in
+        /// <paramref name="matchedStep"/> so the caller can enforce replay protection. RFC 6238 §5.2
+        /// recommends persisting the highest accepted step and rejecting any code whose matched step is
+        /// not greater than it — this also closes replay of a still-in-window neighbouring step, which
+        /// per-step consumption alone would leave open.
+        /// </summary>
+        /// <param name="secret">The shared secret bytes.</param>
+        /// <param name="code">The presented code; surrounding whitespace and spaces are ignored.</param>
+        /// <param name="currentStep">The time step for "now".</param>
+        /// <param name="window">Number of steps to check on each side of <paramref name="currentStep"/>.</param>
+        /// <param name="matchedStep">The step the code matched, when the result is <c>true</c>.</param>
+        /// <returns><c>true</c> if the code matches a step in the window; otherwise <c>false</c>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="window"/> is negative.</exception>
+        public bool TryValidate(ReadOnlySpan<byte> secret, string code, long currentStep, int window, out long matchedStep)
+        {
+            if (window < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(window), window, "TOTP validation window cannot be negative.");
+            }
+
+            matchedStep = 0;
+
+            if (string.IsNullOrWhiteSpace(code))
+            {
+                return false;
+            }
+
+            string normalized = code.Replace(" ", string.Empty, StringComparison.Ordinal).Trim();
+            if (normalized.Length != _digits || !normalized.All(char.IsAsciiDigit))
+            {
+                return false;
+            }
+
+            byte[] expectedBytes = Encoding.ASCII.GetBytes(normalized);
+
+            bool matched = false;
+            for (long step = currentStep - window; step <= currentStep + window; step++)
+            {
+                byte[] candidate = Encoding.ASCII.GetBytes(Generate(secret, step));
+                // Constant-time compare; do not short-circuit the loop on first match so a timing
+                // observer cannot learn which step matched.
+                if (CryptographicOperations.FixedTimeEquals(candidate, expectedBytes))
+                {
+                    matched = true;
+                    matchedStep = step;
+                }
+            }
+
+            return matched;
+        }
+    }
+}


### PR DESCRIPTION
## Why?
EasyReasy.Auth needs low-level building blocks for multi-factor authentication — a TOTP code generator and a way to hold the shared secret encrypted at rest — implemented in-house so this security-critical path has no third-party dependency.

## What?
- **`Rfc6238TotpGenerator`** — RFC 6238 (TOTP) over RFC 4226 (HOTP) with HMAC-SHA1, configurable digit count (6–8) and time-step. Pure and stateless: constant-time comparison, and it reports the matched step so the caller owns replay protection.
- **`ISecretCipher` / `AesGcmSecretCipher`** — AES-256-GCM authenticated encryption for small recoverable secrets (e.g. a per-user TOTP seed), with a self-describing `[version][nonce][tag][ciphertext]` envelope that fails closed on tamper/wrong key.
- README section 12 documenting both, matching Overview and Core Features bullets, and a version bump to 5.4.0 (purely additive).

## Challenges
- The envelope's leading byte is an honest **format version** (`EnvelopeVersion`), deliberately *not* a key-rotation mechanism — key-ring rotation stays application policy rather than being baked into the primitive. The version byte is bound as AAD so it's authenticated alongside the ciphertext.
- Replay guidance follows the RFC 6238 §5.2 high-water-mark pattern (reject any code whose matched step is ≤ the last accepted step), documented for the caller since the library correctly delegates that policy.

## Left for future work
- A behavioral test isolating the version-as-AAD binding is only possible once a second envelope version exists — today the explicit version guard trips before the AAD check.